### PR TITLE
Modernize WebSockets

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
-julia 0.2-
-HttpCommon 0.0.3-
-HttpServer 0.0.4-
+julia 0.3
+HttpCommon 0.0.3
+HttpServer 0.0.4
 Codecs
 Nettle

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.3
+Compat
 HttpCommon 0.0.3
 HttpServer 0.0.4
 Codecs

--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -1,5 +1,6 @@
 module WebSockets
 
+using Compat
 using HttpCommon
 using HttpServer
 using Codecs
@@ -71,17 +72,17 @@ function send_fragment(ws::WebSocket, islast::Bool, data::Array{Uint8}, opcode=0
   b1::Uint8 = (islast ? 0b1000_0000 : 0b0000_0000) | opcode
   if l <= 125
     write(ws.socket,b1)
-    write(ws.socket,uint8(l))
+    write(ws.socket,@compat UInt8(l))
     write(ws.socket,data)
   elseif l <= typemax(Uint16)
     write(ws.socket,b1)
-    write(ws.socket,uint8(126))
-    write(ws.socket,hton(uint16(l)))
+    write(ws.socket,0b01111110)
+    write(ws.socket,hton(@compat Uint16(l)))
     write(ws.socket,data)
   elseif l <= typemax(Uint64)
     write(ws.socket,b1)
-    write(ws.socket,uint8(127))
-    write(ws.socket,hton(uint64(l)))
+    write(ws.socket,0b01111111)
+    write(ws.socket,hton(@compat Uint64(l)))
     write(ws.socket,data)
   else
     error("Attempted to send too much data for one websocket fragment\n")
@@ -163,12 +164,12 @@ function WebSocketFragment(
   ,data::Vector{Uint8})
 
   WebSocketFragment(
-      bool(fin)
-    , bool(rsv1)
-    , bool(rsv2)
-    , bool(rsv3)
+      fin != 0
+    , rsv1 != 0
+    , rsv2 != 0
+    , rsv3 != 0
     , opcode
-    , bool(masked)
+    , masked != 0
     , payload_len
     , maskkey
     , data)


### PR DESCRIPTION
Use Compat

- send_fragment: Rewrite using binary literals and new constructor syntax
- WebSocketFragment constructor: remove deprecated bool()

Drop julia 0.2 support

Also drop prerelease support for HttpCommon and HttpServer