### PR TITLE
Fix #32

### DIFF
--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -242,7 +242,8 @@ function read(ws::WebSocket)
 
   #handle control (non-data) messages
   if is_control_frame(frame)
-    @show handle_control_frame(ws,frame)
+    handle_control_frame(ws,frame)
+    # return the next non-control frame
     return read(ws)
   end
 

--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -248,7 +248,7 @@ function read(ws::WebSocket)
 
   #handle data that uses multiple fragments
   if !frame.is_last
-    return concatenate(frame.data,read(ws))
+    return vcat(frame.data, read(ws))
   end
 
   return frame.data


### PR DESCRIPTION
Looks like the `concatenate` function did not exist, and Julia didn't throw any errors. ¯\ _ (ツ) _ /¯