### PR TITLE
Fix lowercase and decode errors.

### DIFF
--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -328,8 +328,8 @@ function handle(handler::WebSocketHandler, req::Request, client::HttpServer.Clie
 end
 function is_websocket_handshake(handler::WebSocketHandler, req::Request)
     is_get = req.method == "GET"
-    is_upgrade = lowercase(get(req.headers, "Connection", false)) == "upgrade"
-    is_websockets = lowercase(get(req.headers, "Upgrade", false)) == "websocket"
+    is_upgrade = lowercase(get(req.headers, "Connection", "")) == "upgrade"
+    is_websockets = lowercase(get(req.headers, "Upgrade", "")) == "websocket"
     return is_get && is_upgrade && is_websockets
 end
 

--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -301,7 +301,7 @@ function websocket_handshake(request,client)
   end
 
   key = request.headers["Sec-WebSocket-Key"]
-  if length(decode(key)) != 16 # Key must be 16 bytes
+  if length(decode(Base64,key)) != 16 # Key must be 16 bytes
     Base.write(client.sock, Response(400))
     return
   end


### PR DESCRIPTION
After checking out to Websockets master, in [Escher](https://github.com/shashi/Escher.jl), we were getting these error messages as you can see in https://github.com/shashi/Escher.jl/issues/66#issuecomment-134385320.
```julia
ERROR (unhandled task failure): MethodError: `lowercase` has no method matching lowercase(::Bool)
 in is_websocket_handshake at /Users/rohitvarkey/.julia/v0.4/WebSockets/src/WebSockets.jl:332
 in on_message_complete at /Users/rohitvarkey/.julia/v0.4/HttpServer/src/HttpServer.jl:358
 in on_message_complete at /Users/rohitvarkey/.julia/v0.4/HttpServer/src/RequestParser.jl:99
 in http_parser_execute at /Users/rohitvarkey/.julia/v0.4/HttpParser/src/HttpParser.jl:106
 in process_client at /Users/rohitvarkey/.julia/v0.4/HttpServer/src/HttpServer.jl:330
 in anonymous at task.jl:447
```

I've changed the default value to an empty string to prevent this error from happening.