### PR TITLE
Fixes `is_websocket_handshake`  for websocket connections in Firefox.

### DIFF
--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -356,7 +356,8 @@ function handle(handler::WebSocketHandler, req::Request, client::HttpServer.Clie
 end
 function is_websocket_handshake(handler::WebSocketHandler, req::Request)
     is_get = req.method == "GET"
-    is_upgrade = lowercase(get(req.headers, "Connection", "")) == "upgrade"
+    # "upgrade" for Chrome and "keep-alive, upgrade" for Firefox.
+    is_upgrade = contains(lowercase(get(req.headers, "Connection", "")),"upgrade") 
     is_websockets = lowercase(get(req.headers, "Upgrade", "")) == "websocket"
     return is_get && is_upgrade && is_websockets
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,10 @@ using Base.Test
 
 import WebSockets: generate_websocket_key,
                    write_fragment,
-                   read_frame
+                   read_frame,
+                   is_websocket_handshake
+
+import HttpCommon: Request
 
 #is_control_frame is one line, checking one bit.
 #get_websocket_key grabs a header.
@@ -106,4 +109,32 @@ end
 #
 close(io)
 
+# Tests for is_websocket_handshake
+chromeheaders = @compat Dict{String,String}(
+        "Connection"=>"Upgrade",
+        "Upgrade"=>"websocket"
+    )
+chromerequest = Request(
+    "GET",
+    "",
+    chromeheaders,
+    ""
+    )
 
+firefoxheaders = @compat Dict{String,String}(
+        "Connection"=>"keep-alive, Upgrade",
+        "Upgrade"=>"websocket"
+    )
+
+firefoxrequest= Request(
+    "GET",
+    "",
+    firefoxheaders,
+    ""
+    )
+
+handler = WebSocketHandler(x->x); #Dummy handler
+
+for request in [chromerequest, firefoxrequest]
+    @test is_websocket_handshake(handler,request) == true
+end


### PR DESCRIPTION
Firefox seems to have changed the WebSocket connection request header. The request I was receiving on doing 
```javascript
 ws = new WebSocket("ws://localhost:5557/socket/toolbar.jl?w=1272&h=374")
```
 in a Firefox console was

```julia
req = === Resource ====
resource: /socket/toolbar.jl?w=1272&h=374
method: GET
Headers:
    Connection: keep-alive, Upgrade
    Cookie: csrftoken=I7fHePfOC83O0T17X9CS7st3h3VUoZoG
    Sec-WebSocket-Version: 13
    http_minor: 1
    Keep-Alive: 1
    User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:39.0) Gecko/20100101 Firefox/39.0
    Accept-Encoding: gzip, deflate
    Cache-Control: no-cache
    Origin: http://localhost:5557
    Sec-WebSocket-Key: EKPNFAgXUxZHkDGpWOIfsA==
    Sec-WebSocket-Extensions: permessage-deflate
    Host: localhost:5557
    Upgrade: websocket
    Pragma: no-cache
    http_major: 1
    Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
    Accept-Language: en-US,en;q=0.5
data:
=== End Resource ===
```

The `Connection` header has a value of `keep-alive, Upgrade` instead of `Upgrade`. This was leading to refused websocket connections in Firefox. 

This is fixed by checking if `upgrade` is substring of the entire `Connection` header instead of looking for `==`.