### PR TITLE
Update generate_websocket_key with new Nettle API

### DIFF
--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -308,9 +308,8 @@ end
 #   3. Encode the resulting number in base64.
 # This function then returns the string of the base64-encoded value.
 function generate_websocket_key(key)
-  h = HashState(SHA1)
-  update!(h, key*"258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
-  bytestring(encode(Base64, digest!(h)))
+  h = digest("sha1", key*"258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+  bytestring(encode(Base64, h))
 end
 
 # Responds to a WebSocket handshake request.


### PR DESCRIPTION
Addresses https://github.com/JuliaWeb/WebSockets.jl/issues/41.

Only place where I could find Nettle functions used where in the `generate_websocket_key` function. Updated it to use the new API.

Tried to run some Escher pages with this and they worked fine. So I'm hoping nothing else needs to be done.
