### PR TITLE
Replace nettle with mbedtls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
     - linux
     - osx
 julia:
-    - 0.3
     - 0.4
+    - 0.5
     - nightly
 sudo: false
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,4 @@ Compat 0.7.16
 HttpCommon 0.0.3
 HttpServer 0.0.4
 Codecs
-Nettle 0.2.0
+MbedTLS

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.4
 Compat 0.7.16
 HttpCommon 0.0.3
 HttpServer 0.0.4

--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -20,7 +20,7 @@ module WebSockets
 using HttpCommon
 using HttpServer
 using Codecs
-using Nettle
+using MbedTLS
 using Compat; import Compat.String
 
 export WebSocket,
@@ -337,7 +337,7 @@ end
 #   3. Encode the resulting number in base64.
 # This function then returns the string of the base64-encoded value.
 function generate_websocket_key(key)
-    hashed_key = digest("SHA1", key*"258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+    hashed_key = digest(MD_SHA1, key*"258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
     bytestring(encode(Base64, hashed_key))
 end
 


### PR DESCRIPTION
This removes the Nettle.jl dependency, which often causes install problems for Juno.

Since this is just a sha1 hash it could probably be replaced by SHA.jl, but MbedTLS is used by the rest of the web stack anyway.