### PR TITLE
Dropping Julia 0.4, upgrade to 0.5 and 0.6. Fix examples.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
-julia 0.4
-Compat 0.7.16
+julia 0.5
+Compat 0.16.0
 HttpCommon 0.0.3
 HttpServer 0.0.4
 Codecs

--- a/examples/chat-client.html
+++ b/examples/chat-client.html
@@ -33,7 +33,7 @@
         var you = "you";
         connection.onmessage = function( message ){
             window.lastmessage = message;
-            $("#content").prepend( $("<p class='received'></p>").html( message.data ) );
+            $("#content").append( $("<p class='received'></p>").html( message.data ) );
         }
         function changeUsername( username ){
             you = username;
@@ -42,7 +42,7 @@
         }
         function sendMessage( message ){
             connection.send('say:'+ message);
-            $("#content").prepend( $("<p class='sent'></p>").html( you + ": " + message ) );
+            $("#content").append( $("<p class='sent'></p>").html( you + ": " + message ) );
         }
         $("#sayer input[type=submit]").click(function(){
             if( $("#sayer input[name=say]").val().replace(/\s/gi,'').length )

--- a/examples/chat.jl
+++ b/examples/chat.jl
@@ -6,7 +6,7 @@ global connections = Dict{Int,WebSocket}()
 global usernames   = Dict{Int,String}()
 
 function decodeMessage( msg )
-    bytestring(msg)
+    String(copy(msg))
 end
 
 wsh = WebSocketHandler() do req, client
@@ -30,7 +30,7 @@ wsh = WebSocketHandler() do req, client
     end
 end
 
-onepage = readall(Pkg.dir("WebSockets","examples","chat-client.html"))
+onepage = readstring(Pkg.dir("WebSockets","examples","chat-client.html"))
 httph = HttpHandler() do req::Request, res::Response
   Response(onepage)
 end

--- a/examples/repl-client.html
+++ b/examples/repl-client.html
@@ -26,12 +26,20 @@
         var you = "you";
         connection.onmessage = function( message ){
             window.lastmessage = message;
-            $("#content").prepend( $("<p class='received'></p>").html( message.data ) );
+            $("#content").append( $("<p class='received'></p>").html( message.data ) );
         }
         function sendMessage( message ){
-            connection.send(message);
-            $("#content").prepend( $("<p class='sent'></p>").html( you + ": " + message ) );
-        }
+            if(typeof connection === 'undefined' || connection === null){
+                    $("#content").append( $("<p class='received'>Connection not defined</p>"));
+                } else {    
+                            if(connection.readyState==1){
+                                        connection.send(message);
+                                        $("#content").append( $("<p class='sent'></p>").html( you + ": " + message ) );
+                                    } else {
+                                        $("#content").append( $("<p class='received'>Connection not ready</p>"));
+                                    };
+            };
+        };
         $("#sayer input[type=submit]").click(function(){
             if( $("#sayer input[name=say]").val().replace(/\s/gi,'').length )
                 sendMessage( $("#sayer input[name=say]").val() );


### PR DESCRIPTION
modified:   REQUIRE                           Compat version covering…… relevant changes in 0.6
modified:   examples/chat-client.html  Prepending messages -> Appending.
modified:   examples/chat.jl                0.6 update (take_buf, Array constructors)
modified:   examples/repl-client.html   Prepending messages -> Appending. Javascript feedback, no script error when connection close.
modified:   examples/server.jl              0.6 update (take_buf, Array constructors). 'Eval' error handling and feedback. More type stability.
modified:   src/WebSockets.jl               0.6 update (take_buf, Array constructors). Precompilation.
modified:   test/runtests.jl                   0.6 update (take_buf, Array constructors)