### PR TITLE
Binary browser test, performance logging

### DIFF
--- a/test/browsertest.html
+++ b/test/browsertest.html
@@ -1,34 +1,133 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <title>WebSockets browsertest.html</title>
+	<title>WS text</title>
+	<meta charset="utf-8">
   </head>
 <body>
-<p>Test tries to open some websockets, browser says hello from browser, and continues to echo messages from server.</p>
+<p>Test tries to open three different websockets.
+</p>
+<ul>
+<li> ws1 General </li>
+<li> ws2 Server approved subprotocol </li>
+<li> ws3 Server unapproved subprotocol </li>
+</ul>
+<p>
+Websocket initiates with sending "Ping me!" with signature.<br>
+<br>They echo received messages, but react to: 
+<br>&nbsp;&nbsp;&quot;<i id="exitmsg"></i>&quot;
+<p>
 <p id = "init"></p>
 <p>&nbsp;&nbsp;This is <b id = "browserid"> ... </b></p>
 <div id = "ws1" style="border:thick solid black;"><p>ws1 Websocket</p></div>
 <div id = "ws2" style="border:thick solid black;"><p>ws2 Websocket: websocket-testprotocol</p></div>
 <div id = "ws3" style="border:thick solid black;"><p>ws3 Websocket: server_denies_protocol</p></div>
-</body>
+
 <script>
+var exitmsg = "Close, wait, and navigate to: browsertest2.html"
 
-function addwebsocket_test(){console.log("Add websocket general");
+window.onload= function(){
+	plog("init", "<p>:window.onload</p>");
+	plog("browserid", getBrowser());
+	plog("exitmsg", exitmsg);
+
+	ws1 = addwebsocket("ws1");
+	ws2 = addwebsocket("ws2", "websocket-testprotocol");
+//	ws3 = addwebsocket("ws3", "server_denies");
+	// control flow cedes to ws events.
+} 
+
+// log to DOM element ws 
+function plog(ws, shtm){
+	document.getElementById(ws).innerHTML += shtm
+} 
+
+function addwebsocket(instancename, subprotocol){
 	var wsuri = document.URL.replace("http:","ws:");
-	return new WebSocket(wsuri)
-} // addwebsocket_test
+	if (typeof subprotocol === "undefined") {
+		var ws = new WebSocket(wsuri)
+	} else {
+		var ws = new WebSocket(wsuri, subprotocol)
+	}
+	ws.mynam = instancename;
+	ws.onclose = function(e){
+		plog(e.target.mynam, "<p>: " + e.target.mynam + ".onclose:" +
+			"wasClean: " + e.wasClean + ";  " +
+			"code: " + e.code + ";  " + codeDesc[e.code] + ";  " +
+			"reason: " + e.reason + ";  " +
+			"<br>&nbsp;&nbsp;Websocket state is now " + e.target.readyState +
+			" " + readystateDesc[e.target.readyState] + ".</p>");
+	}
+	ws.onerror = function(e){
+		plog(e.target.mynam, "<p>: " + e.target.mynam + ".onerror: " +
+			"<br>&nbsp;&nbsp;Websocket state is now " + e.target.readyState +
+			" " + readystateDesc[e.target.readyState] + ".</p>");
+		}
+	ws.onopen = function(e){
+		var msg = "Ping me! This is " + e.target.mynam ;
+		if(e.target.protocol!==""){
+			msg += " on subprotocol " + e.target.protocol
+		}
+		msg += " in browser " + getBrowser() 
+		plog(e.target.mynam, "<p>: " + e.target.mynam + ".onopen: " +
+			"<br>&nbsp;&nbsp;Websocket state is now " + e.target.readyState +
+			" " + readystateDesc[e.target.readyState] + 
+			"</p><p>&nbsp;&nbsp;..Sending message: " + msg + "</p>");
+		e.target.send(msg);
+	}
+	ws.onmessage	= function(e){
+		var msg = e.data;
+		plog(e.target.mynam, "<p>: " + e.target.mynam + ".onmessage: " + msg + "  </p>");
+		if(msg == exitmsg) {
+				plog(e.target.mynam, "<p>&nbsp;&nbsp; Reveived :" + msg + "</p>");
+				var file = msg.split(": ")[1];
+				plog(e.target.mynam, "<p>&nbsp;&nbsp; Calling close, will navigate to "+ file + " in 2 seconds</p>");
+				e.target.close()
+				setTimeout(navigate, 2000, file);
+			} else {
+				var msgecho = e.target.mynam + " echo: " + e.data;
+				plog(e.target.mynam, "<p>&nbsp;&nbsp;" + msgecho + "</p>");
+				e.target.send(e.target.mynam + " echo: " + e.data)
+			}
+	}
+	plog(instancename, "<p>" + instancename + " created with event handlers.</p>");
+	return ws
+} // addwebsocket
 
-function addwebsocket_subprotocol_test(){console.log("Add websocket acceptable subprotocol");
-	var wsuri = document.URL.replace("http:","ws:");
-	return new WebSocket(wsuri, "websocket-testprotocol")
-} // addwebsocket_subprotocol_test
 
-function addwebsocket_server_denies(){console.log("Add websocket inacceptable subprotocol");
-	var wsuri = document.URL.replace("http:","ws:");
-	return new WebSocket(wsuri, "server_denies")
-} // addwebsocket_server_denies
 
+// https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
+// small change Chrome > Blink, PhantomJS.
+var getBrowser = function() {
+	var isPhantom =  (navigator.userAgent == 'PhantomJS')
+	// Opera 8.0+
+	var isOpera = (!!window.opr && !!opr.addons) || !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
+	// Firefox 1.0+
+	var isFirefox = typeof InstallTrigger !== 'undefined';
+	// Safari 3.0+ "[object HTMLElementConstructor]"
+	var isSafari = /constructor/i.test(window.HTMLElement) || (function (p) { return p.toString() === "[object SafariRemoteNotification]"; })(!window['safari'] || (typeof safari !== 'undefined' && safari.pushNotification));
+	// Internet Explorer 6-11
+	var isIE = /*@cc_on!@*/false || !!document.documentMode;
+	// Edge 20+
+	var isEdge = !isIE && !!window.StyleMedia;
+	// Chrome 1+
+	var isChrome = !!window.chrome && !!window.chrome.webstore;
+	// Blink engine detection
+	var isBlink = (isChrome || isOpera) && !!window.CSS;
+	if(isPhantom){return "Phantom"};
+	if(isChrome){return "Chrome"};
+	if(isBlink){return "Blink"};
+	if(isEdge){return "Edge"};
+	if(isIE){return "Internet Explorer"};
+	if(isSafari){return "Safari"};
+	if(isFirefox){return "Firefox"};
+	if(isOpera){return "Opera"};
+	return "unknown";
+}
+
+function navigate(file){
+	window.location.href = file
+}
 var codeDesc ={1000:"Normal",
 1001:"Going Away",
 1002:"Protocol Error",
@@ -50,141 +149,6 @@ var readystateDesc ={0:"CONNECTING",
 1:"OPEN",
 2:"CLOSING",
 3:"CLOSED"};
-
-window.onload= function(){
-		document.getElementById("init").innerHTML = "<p>:window.onload";
-		document.getElementById("browserid").innerHTML = getBrowser();
-
-		ws1 = addwebsocket_test();
-		ws1.onclose = function(e){
-				document.getElementById("ws1").innerHTML +=
-					"<p>: ws1.onclose event called with " +
-					"wasClean: " + e.wasClean + ";  " +
-					"code: " + e.code + ";  " + codeDesc[e.code] + ";  " +
-					"reason: " + e.reason + ";  " +
-					"<br>&nbsp;&nbsp;Websocket state is now " + ws1.readyState +
-					" " + readystateDesc[ws1.readyState] + ".</p>";
-					}
-		ws1.onerror = function(e){
-				document.getElementById("ws1").innerHTML += "<p>: ws1.onerror. " +
-					"<br>&nbsp;&nbsp;Websocket state is now " + ws1.readyState +
-					" " + readystateDesc[ws2.readyState] + ".</p>";
-						}
-		ws1.onopen = function(){
-				document.getElementById("ws1").innerHTML += "<p>: ws1.onopen. " +
-					"<br>&nbsp;&nbsp;Websocket state is now " + ws1.readyState +
-					" " + readystateDesc[ws1.readyState] + ".</p>";
-				msg = "Hello from socket ws1 in browser " + getBrowser();
-				document.getElementById("ws1").innerHTML += "<p>&nbsp;&nbsp;..Sending message: " + msg + "</p>";
-				ws1.send(msg);
-						}
-		ws1.onmessage	= function(e){
-				document.getElementById("ws1").innerHTML += "<p>: ws1.onmessage: " + e.data + "  </p>";
-				if(e.data=="YOU hang up!"){
-						document.getElementById("ws1").innerHTML += "<p>&nbsp;&nbsp; (hanging up, no echo).</p>";
-						ws1.close()
-					} else {
-						document.getElementById("ws1").innerHTML += "<p>&nbsp;&nbsp; echo: " + e.data + "  </p>";
-						ws1.send(e.data)
-					}
-				}
-
-		ws2 = addwebsocket_subprotocol_test();
-		ws2.onclose = function(e){
-				document.getElementById("ws2").innerHTML +=
-					"<p>: ws2.onclose event called with " +
-					"wasClean: " + e.wasClean + ";  " +
-					"code: " + e.code + ";  " + codeDesc[e.code] + ";  " +
-					"reason: " + e.reason + ";  " +
-					"<br>&nbsp;&nbsp;Websocket state is now " + ws2.readyState +
-					" " + readystateDesc[ws2.readyState] + ".</p>";
-					}
-		ws2.onerror = function(e){
-				document.getElementById("ws2").innerHTML += "<p>: ws2.onerror. " +
-					"<br>&nbsp;&nbsp;Websocket state is now " + ws2.readyState +
-					" " + readystateDesc[ws2.readyState] + ".</p>";
-						}
-		ws2.onopen = function(){
-				document.getElementById("ws2").innerHTML += "<p>: ws2.onopen. " +
-					"<br>&nbsp;&nbsp;Websocket state is now " + ws2.readyState +
-					" " + readystateDesc[ws2.readyState] + ".</p>";
-				msg = "Hello from socket ws2 in browser " + getBrowser();
-				document.getElementById("ws2").innerHTML += "<p>&nbsp;&nbsp;..Sending message: " + msg + "</p>";
-				ws2.send(msg);
-						}
-		ws2.onmessage	= function(e){
-				document.getElementById("ws2").innerHTML += "<p>: ws2.onmessage: " + e.data + "  </p>";
-				if(e.data=="YOU hang up!"){
-						document.getElementById("ws2").innerHTML += "<p>&nbsp;&nbsp; (hanging up, no echo).</p>";
-						ws2.close()
-					} else {
-						document.getElementById("ws2").innerHTML += "<p>&nbsp;&nbsp; echo: " + e.data + "  </p>";
-						ws2.send(e.data)
-					}
-				}
-
-		ws3 = addwebsocket_server_denies();
-		ws3.onclose = function(e){
-				document.getElementById("ws3").innerHTML +=
-					"<p>: ws3.onclose event called with " +
-					"wasClean: " + e.wasClean + ";  " +
-					"code: " + e.code + ";  " + codeDesc[e.code] + ";  " +
-					"reason: " + e.reason + ";  " +
-					"<br>&nbsp;&nbsp;Websocket state is now " + ws3.readyState +
-					" " + readystateDesc[ws3.readyState] + ".</p>";
-					}
-		ws3.onerror = function(e){
-				document.getElementById("ws3").innerHTML += "<p>: ws3.onerror. " +
-					"<br>&nbsp;&nbsp;Websocket state is now " + ws3.readyState +
-					" " + readystateDesc[ws3.readyState] + ".</p>";
-						}
-		ws3.onopen = function(){
-				document.getElementById("ws3").innerHTML += "<p>: ws3.onopen. " +
-					"<br>&nbsp;&nbsp;Websocket state is now " + ws3.readyState +
-					" " + readystateDesc[ws3.readyState] + ".</p>";
-				msg = "Hello from socket 3 in browser " + getBrowser();
-				document.getElementById("ws3").innerHTML += "<br>&nbsp;&nbsp;..Sending message: " + msg + "</p>";
-				ws3.send(msg);
-						}
-		ws3.onmessage	= function(e){
-				document.getElementById("ws3").innerHTML += "<p>: ws3.onmessage: " + e.data + "  </p>";
-				if(e.data=="YOU hang up!"){
-						document.getElementById("ws3").innerHTML += "<p>&nbsp;&nbsp; (hanging up, no echo).</p>";
-						ws3.close()
-					} else {
-						document.getElementById("ws3").innerHTML += "<p>&nbsp;&nbsp; echo: " + e.data + "  </p>";
-						ws3.send(e.data)
-					}
-				}
-		} // window.onload
-
-// https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
-// small change Chrome > Blink.
-var getBrowser = function() {
-  var isPhantom =  (navigator.userAgent == 'PhantomJS')
-	// Opera 8.0+
-	var isOpera = (!!window.opr && !!opr.addons) || !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
-	// Firefox 1.0+
-	var isFirefox = typeof InstallTrigger !== 'undefined';
-	// Safari 3.0+ "[object HTMLElementConstructor]"
-	var isSafari = /constructor/i.test(window.HTMLElement) || (function (p) { return p.toString() === "[object SafariRemoteNotification]"; })(!window['safari'] || (typeof safari !== 'undefined' && safari.pushNotification));
-	// Internet Explorer 6-11
-	var isIE = /*@cc_on!@*/false || !!document.documentMode;
-	// Edge 20+
-	var isEdge = !isIE && !!window.StyleMedia;
-	// Chrome 1+
-	var isChrome = !!window.chrome && !!window.chrome.webstore;
-	// Blink engine detection
-	var isBlink = (isChrome || isOpera) && !!window.CSS;
-  if(isPhantom){return "Phantom"};
-	if(isChrome){return "Chrome"};
-	if(isBlink){return "Blink"};
-	if(isEdge){return "Edge"};
-	if(isIE){return "Internet Explorer"};
-	if(isSafari){return "Safari"};
-	if(isFirefox){return "Firefox"};
-	if(isOpera){return "Opera"};
-	return "unknown";
-	}
 </script>
+</body>
 </html>

--- a/test/browsertest.jl
+++ b/test/browsertest.jl
@@ -1,60 +1,135 @@
 # Included in runtests at the end.
+# Can also be run directly.
+# Launches available browsers on browsertest.html.
+# Websockets are intiated by the browser / web page. 
+# Handler_functions_websockets respond and store allocations & etc.
+# After a successfull exchange, the browsers navigate to a second html page
+# for binary performance tests. In the end, all websockets are closed
+# and a summary is output.
 
+cd(Pkg.dir("WebSockets","test"))
+using WebSockets
+using Base.Test
 const WEBSOCKETS = Dict{Int, WebSockets.WebSocket}()
+const RECEIVED_WS_MSGS_TIME = Dict{Int, Vector{Float64}}()
+const RECEIVED_WS_MSGS_ALLOCATED = Dict{Int, Vector{Int64}}()
+const RECEIVED_WS_MSGS_LENGTH = Dict{Int, Vector{Int64}}()
 const WEBSOCKETS_SUBPROTOCOL = Dict{Int, WebSockets.WebSocket}()
+const WEBSOCKETS_BINARY = Dict{Int, WebSockets.WebSocket}()
+# Note that only text messages are stored. Binary messages are discarded.
 const RECEIVED_WS_MSGS = Dict{Int, Vector{String}}()
-global noofresponders = 0
 
+# Logs from travis indicate it takes 7 s to fire up Safari and
+# have the first websocket open. This can easily increase if more
+# browsers become available.
+const FIRSTWAIT = Base.Dates.Second(20)
+const MAXWAIT = Base.Dates.Second(60*15)
+global n_responders = 0
 include("functions_server.jl")
-
+closeall()
 server = start_ws_server_async()
-
-# Give the server 5 seconds to get going.
-sleep(5)
-info("We waited 5 seconds after starting the server.")
-for (ke, va) in WEBSOCKETS
-    if isopen(va)
-        info("Somebody opened a websocket during that time. Closing it now.")
-        close(va)
-    end
-end
-
-info("This OS is ", Sys.KERNEL)
 include("functions_open_browsers.jl")
-noofbrowsers = open_all_browsers()
-const CLOSEAFTER = Base.Dates.Second(15)
-t0 = now()
-while now()-t0 < CLOSEAFTER && length(keys(RECEIVED_WS_MSGS)) < noofbrowsers * 2
-    sleep(1)
-end
-info("Received messages on ", length(keys(RECEIVED_WS_MSGS)), " sockets.")
-info("Tell the special sockets to initiate a close.")
-for (ke, va) in WEBSOCKETS_SUBPROTOCOL
-    writeto(ke, "YOU hang up!")
-end
+info("This OS is $(string(Sys.KERNEL))\n")
+n_browsers = 0
+n_browsers += open_testpage("phantomjs")
+#n_browsers += open_all_browsers()
 
-sleep(10)
-info("Closing down after ", now()-t0, " including 10 seconds pause.")
-countstillopen = 0
-for (ke, va) in WEBSOCKETS
-    if isopen(va)
-        info(" Websocket to close: ", va)
-        countstillopen +=1
-        close(va)
+# Control flow passes to async handler functions
+
+if n_browsers > 0
+    info("Sleeping main thread for an initial minimum of $FIRSTWAIT\n")
+    t0 = now()
+    while now()-t0 < FIRSTWAIT
+        sleep(1)
+    end
+    contwait = true
+    while contwait && now()-t0 < MAXWAIT
+        # All websockets close briefly when navigating from browsertest.html to browsertest2.html
+        # So we require two consecutive checks for websockets before exiting, with 2 seconds between.
+        contwait = count_open_websockets() > 0
+        if !contwait
+            sleep(2)
+            passedtime = now() - t0
+            exitlatestin = MAXWAIT + t0- now()
+            info("$(div(passedtime.value, 1000)) s passed. Max remaining test time $(div(exitlatestin.value, 1000)) s\n")
+        end
+        sleep(.5)
+        contwait = contwait && count_open_websockets() > 0
     end
 end
-sleep(5)
-close(server)
-server = nothing
-info("Openened $noofbrowsers, from which $noofresponders requested the HTML page.")
-info("Received messages for each websocket:")
-display(RECEIVED_WS_MSGS)
-println()
-@test countstillopen == noofresponders
-countmessages = 0
-for (ke, va) in RECEIVED_WS_MSGS
-    countmessages += length(va)
+n_opensockets = count_open_websockets()
+
+closeall()
+
+# sum up
+allocs = Vector{Int64}()
+times = Vector{Float64}()
+lengths = Vector{Int64}()
+n_msgs = 0
+n_text = 0
+n_ws = 0
+for ke in keys(WEBSOCKETS)
+    n_ws += 1
+    for msgno = 1:length(RECEIVED_WS_MSGS_LENGTH[ke])
+        if RECEIVED_WS_MSGS_LENGTH[ke][msgno] > 0
+            n_msgs += 1
+            push!(allocs, RECEIVED_WS_MSGS_ALLOCATED[ke][msgno])
+            push!(times, RECEIVED_WS_MSGS_TIME[ke][msgno])
+            push!(lengths, RECEIVED_WS_MSGS_LENGTH[ke][msgno])
+            if haskey(RECEIVED_WS_MSGS, ke)
+                n_text += 1
+            end
+        end
+    end
 end
-@test length(keys(RECEIVED_WS_MSGS)) == noofresponders * 2
-@test countmessages == noofresponders * 6
-nothing
+n_binary = n_msgs - n_text
+
+# print summary
+info("Spawned $n_browsers browsers. $n_browsers made requests. Opened $n_ws sockets, $n_opensockets did not close as intended.")
+info("Received $n_msgs messages, $n_text text and $n_binary binary, $(round(sum(lengths)/ 1000 / 1000,3)) Mb, sent a similar amount.")
+info("Text messages received per websocket:")
+display.(RECEIVED_WS_MSGS)
+
+if n_msgs > 0
+    maxlength = maximum( lengths )
+    minlength = minimum( va -> va > 0.0 ? va:typemax(va), lengths )
+    avglength = sum(lengths) / n_msgs
+
+    maxaloc = maximum(  va -> va < Inf ? va:0.0, allocs ./ lengths )
+    minaloc = minimum( va -> va > 0.0 ? va:typemax(va), allocs ./ lengths )
+    avgaloc = sum(allocs) / sum(lengths)
+
+    maxtime = maximum(va -> va < Inf ? va:0.0, times)
+    mintime = minimum(va -> va > 0.0 ? va:typemax(va), times)
+    avgtime = sum(times) / n_msgs
+
+    maxspeed = maximum(va -> va < Inf ? va:0.0, lengths ./ times)
+    minspeed = minimum(va -> va > 0.0 ? va:typemax(va), lengths ./ times)
+    avgspeed = sum(lengths) / sum(times)
+
+    info("Length of messages received\n",
+        "\t\tAverage length:\t\t", round(avglength / 1000, 3), " kB\n",
+        "\t\t\Minimum :\t\t", minlength , " b\n",
+        "\t\t\Maximum :\t\t", round(maxlength / 1000 / 1000 , 3), " Mb\n")
+
+    info("Time spent reading and waiting for received messages\n",
+        "\t\tAverage time:\t\t", round(avgtime, 4), " s\n",
+        "\t\t\Minimum :\t\t", mintime , " s\n",
+        "\t\t\Maximum :\t\t", maxtime, " s\n")
+
+    info("Reading speed (strongly affected by the active browsers)\n",
+        "\t\tAverage speed:\t", round(avgspeed / 1000 / 1000, 3), " Mb/s\n",
+        "\t\t\Minimum :\t", round(minspeed / 1000 / 1000 , 10), " Mb/s\n",
+        "\t\t\Maximum :\t", round(maxspeed / 1000 / 1000, 3), " Mb/s\n")
+
+    info("Allocations for reading, bytes allocated per byte received\n",
+        "\t\tAverage allocation:\t", round(avgaloc, 3), "\n",
+        "\t\t\Minimum :\t\t", round(minaloc, 3), "\n",
+        "\t\t\Maximum :\t\t", round(maxaloc, 3), "\n",)
+
+else
+    info("Failure on speed / allocation test.")
+end
+
+@test n_opensockets == 0
+@test n_msgs == n_responders * 21

--- a/test/browsertest.jl
+++ b/test/browsertest.jl
@@ -32,7 +32,7 @@ server = start_ws_server_async()
 include("functions_open_browsers.jl")
 info("This OS is $(string(Sys.KERNEL))\n")
 n_browsers = 0
-#n_browsers += open_testpage("phantomjs")
+#n_browsers += open_testpage("iexplore")
 n_browsers += open_all_browsers()
 
 # Control flow passes to async handler functions
@@ -135,4 +135,4 @@ else
 end
 
 @test n_opensockets == 0
-@test n_msgs == n_responders * 21
+@test n_msgs == n_responders * 37

--- a/test/browsertest.jl
+++ b/test/browsertest.jl
@@ -23,7 +23,7 @@ const RECEIVED_WS_MSGS = Dict{Int, Vector{String}}()
 # Logs from travis indicate it takes 7 s to fire up Safari and
 # have the first websocket open. This can easily increase if more
 # browsers become available.
-const FIRSTWAIT = Base.Dates.Second(20)
+const FIRSTWAIT = Base.Dates.Second(2)
 const MAXWAIT = Base.Dates.Second(60*15)
 global n_responders = 0
 include("functions_server.jl")
@@ -32,7 +32,7 @@ server = start_ws_server_async()
 include("functions_open_browsers.jl")
 info("This OS is $(string(Sys.KERNEL))\n")
 n_browsers = 0
-#n_browsers += open_testpage("iexplore")
+#n_browsers += open_testpage("firefox")
 n_browsers += open_all_browsers()
 
 # Control flow passes to async handler functions
@@ -61,7 +61,7 @@ end
 n_opensockets = count_open_websockets()
 
 closeall()
-
+info(Dates.format(now(), "HH:MM:SS"), "\tClosed web sockets and servers.")
 # sum up
 allocs = Vector{Int64}()
 times = Vector{Float64}()
@@ -88,10 +88,10 @@ n_binary = n_msgs - n_text
 # print summary
 info("Spawned $n_browsers browsers. $n_browsers made requests. Opened $n_ws sockets, $n_opensockets did not close as intended.")
 info("Received $n_msgs messages, $n_text text and $n_binary binary, $(round(sum(lengths)/ 1000 / 1000,3)) Mb, sent a similar amount.")
-info("Text messages received per websocket:")
-for m in RECEIVED_WS_MSGS
-	display(m)
-end
+
+
+
+
 
 if n_msgs > 0
     maxlength = maximum( lengths )
@@ -129,6 +129,11 @@ if n_msgs > 0
         "\t\tAverage allocation:\t", round(avgaloc, 3), "\n",
         "\t\t\Minimum :\t\t", round(minaloc, 3), "\n",
         "\t\t\Maximum :\t\t", round(maxaloc, 3), "\n",)
+
+    info("Text messages received per websocket:")
+    for m in RECEIVED_WS_MSGS
+        display(m)
+    end
 
 else
     info("Failure on speed / allocation test.")

--- a/test/browsertest.jl
+++ b/test/browsertest.jl
@@ -8,6 +8,7 @@
 # and a summary is output.
 
 cd(Pkg.dir("WebSockets","test"))
+using Compat
 using WebSockets
 using Base.Test
 const WEBSOCKETS = Dict{Int, WebSockets.WebSocket}()
@@ -31,8 +32,8 @@ server = start_ws_server_async()
 include("functions_open_browsers.jl")
 info("This OS is $(string(Sys.KERNEL))\n")
 n_browsers = 0
-n_browsers += open_testpage("phantomjs")
-#n_browsers += open_all_browsers()
+#n_browsers += open_testpage("phantomjs")
+n_browsers += open_all_browsers()
 
 # Control flow passes to async handler functions
 
@@ -88,7 +89,9 @@ n_binary = n_msgs - n_text
 info("Spawned $n_browsers browsers. $n_browsers made requests. Opened $n_ws sockets, $n_opensockets did not close as intended.")
 info("Received $n_msgs messages, $n_text text and $n_binary binary, $(round(sum(lengths)/ 1000 / 1000,3)) Mb, sent a similar amount.")
 info("Text messages received per websocket:")
-display.(RECEIVED_WS_MSGS)
+for m in RECEIVED_WS_MSGS
+	display(m)
+end
 
 if n_msgs > 0
     maxlength = maximum( lengths )

--- a/test/browsertest2.html
+++ b/test/browsertest2.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+	<title>WS binary</title>  
+	<meta charset="utf-8">
+  </head>
+<body>
+<p>This second test page </p>
+<ul>
+<li>opens a websocket subprotocol ""websocket-test-binary" </li>
+<li>sends a small image cropped from the box below</li>
+<li>when pictures are received on the websocket, displays them in the next box</li>
+<li>each received picture triggers sending a larger image, up to a </li>
+<li>Closes websocket when an image on or over the limit size is received.</li>
+</ul>
+
+<p id = "init">
+</p>
+<p>&nbsp;&nbsp;This is <b id = "browserid"> ... </b>
+</p>
+<div>
+<h3>Source image </h3>
+<canvas id = "canv" width = "1920" height = "400" style="border:thick solid green;">Canvas</canvas>
+<p>
+</div>
+<div>
+<h3>Destination image </h3>
+<canvas id = "canv_viajulia" width = "1920" height = "400" style="border:thick solid green;">Canvas</canvas>
+</div>
+<div id = "ws10" style="border:thick solid black;"><p>ws10 Websocket</p></div>
+
+<script>
+var recvwidth = 0;
+var recvheight = 0;
+var recvbyteperpixel = 0;
+var width = 0;
+var height = 0;
+var widthstep = 30*2;
+var heightstep = 17*2;
+var maxwidth = 1920/4; // reduced because of slow Internet Explorer 11 canvas draw option.
+var maxheight = 1088/4;
+var recvbyteperpixel = 0;
+
+window.onload= function(){
+	plog("init", "<p>:window.onload</p>");
+	plog("browserid", getBrowser());
+	ws10 = addwebsocket("ws10", "websocket-test-binary");
+	// control flow cedes to events.
+}
+
+// log to DOM element ws 
+function plog(ws, shtm){
+	document.getElementById(ws).innerHTML += shtm
+} 
+
+function addwebsocket(instancename, subprotocol){
+	var wsuri = document.URL.replace("http:","ws:");
+	if (typeof subprotocol === "undefined") {
+		var ws = new WebSocket(wsuri)
+	} else {
+		var ws = new WebSocket(wsuri, subprotocol)
+	}
+	ws.mynam = instancename;
+	ws.onclose = function(e){
+		plog(e.target.mynam, "<p>: " + e.target.mynam + ".onclose:" +
+			"wasClean: " + e.wasClean + ";  " +
+			"code: " + e.code + ";  " + codeDesc[e.code] + ";  " +
+			"reason: " + e.reason + ";  " +
+			"<br>&nbsp;&nbsp;Websocket state is now " + e.target.readyState +
+			" " + readystateDesc[e.target.readyState] + ".</p>");
+	}
+	ws.onerror = function(e){
+		plog(e.target.mynam, "<p>: " + e.target.mynam + ".onerror: " +
+			"<br>&nbsp;&nbsp;Websocket state is now " + e.target.readyState +
+			" " + readystateDesc[e.target.readyState] + ".</p>");
+	}
+	ws.onopen = function(e){
+		plog(e.target.mynam, "<p>: " + e.target.mynam + ".onopen: " +
+			"<br>&nbsp;&nbsp;Websocket state is now " + e.target.readyState +
+			" " + readystateDesc[e.target.readyState] + 
+			"</p><p>&nbsp;&nbsp;..Setting binaryType = &quot;arraybuffer&quot;</p>");
+		e.target.binaryType = "arraybuffer";
+		plog(e.target.mynam, "<p>&nbsp;&nbsp;..Calling send_increasing_size_image</p>");
+		send_increasing_size_image()	
+	}
+	ws.onmessage	= function(e){
+		plog(e.target.mynam, "<p>: " + e.target.mynam + ".onmessage:</p>");
+		plog(e.target.mynam, "<p>: Negotiated extensions: " + e.target.extensions + "</p>");
+		if(e.data instanceof ArrayBuffer){
+			plog(e.target.mynam, "<p>&nbsp;&nbsp; Received an ArrayBuffer</p>");
+			var inarray = new Uint8ClampedArray(e.data);
+			var inbytelen = inarray.byteLength;
+			if(inbytelen ==6){
+				// Reveive a header, store variables in outside scope.
+				plog(e.target.mynam, 
+						"<p>&nbsp;&nbsp;&nbsp;&nbsp;which is a header of length 6 bytes.</p>");
+				var inarray16 = new Uint16Array(e.data);
+				recvheight = inarray16[0]
+				recvwidth = inarray16[1]
+				recvbyteperpixel = inarray16[2]
+				plog(e.target.mynam, 
+					"<p>&nbsp;&nbsp;&nbsp;&nbsp;width: " + recvwidth + " height: " + 
+					 recvheight + " byteperpixel: " + recvbyteperpixel + "</p>");		
+			} else if (inbytelen == recvheight*recvwidth*recvbyteperpixel) {
+				// Display this picture
+				plog(e.target.mynam, 
+					"<p>&nbsp;&nbsp;&nbsp;&nbsp;which corresponds to height * width * byteperpixel.</p>");
+				var canva = document.getElementById("canv_viajulia");
+				var context = canva.getContext("2d");
+				if(getBrowser()=="Internet Explorer"){
+					putImageDataExplorer(context, inarray, recvwidth, recvheight);
+				} else {
+					try {
+						var image =  new ImageData(inarray, recvwidth, recvheight); 
+						context.putImageData(image, 0, 0);
+						}
+					catch(err) {
+						plog(e.target.mynam, "new ImageData constructor not supported by " + getBrowser() + ", can't display but that's okay.")
+					}
+				}
+				// Continue the exchange by sending a larger picture up to a limit.
+				send_increasing_size_image()
+			} else {
+				plog(e.target.mynam, "<p>&nbsp;&nbsp;&nbsp;&nbsp;which is of unexpected length.</p>");
+			}
+		} else {
+				plog(e.target.mynam, "<p>&nbsp;&nbsp; Received something other than arraybuffer</p>");
+		}
+	}
+	plog(instancename, "<p>" + instancename + " created with event handlers.</p>");
+	return ws
+} // addwebsocket
+
+function send_increasing_size_image(){
+	// start by sending a small image. Increase size of image
+	// every time called.
+	width += widthstep;
+	height += heightstep;
+	if (width <= maxwidth){
+		var canva = document.getElementById("canv");
+		var context = canva.getContext("2d");
+		if(width==widthstep){
+			// first time called, assuming the global starts at zero.
+			context.fillStyle = "green";
+			context.fillRect(0,0,99,99);
+		}
+		var byteperpixel = 4;
+		var buffer = new ArrayBuffer(6);
+		var dv = new DataView(buffer, 0);
+		dv.setInt16(0, width)
+		dv.setInt16(2, height)
+		dv.setInt16(4, byteperpixel)
+		ws10.send(buffer)
+		ws10.send(context.getImageData(0,0, width, height).data.buffer)
+		plog("ws10", "<p>&nbsp;&nbsp;..sending arraybuffer, " + buffer.byteLength/1024 + " kB</p>");
+	} else {
+		finishtest()
+	}
+}
+function finishtest(){
+	plog("ws10", "<p>&nbsp;&nbsp;..Closing without sending anything since images size limit is reached</p>");
+	ws10.close(1000, codeDesc[1000]);
+	// add navigation here if adding more tests.
+}
+// this is of course terribly slow and may hang the browser for a good while.
+function putImageDataExplorer(ctx, data, width, height) {
+  var existimage = ctx.getImageData(0, 0, width, height);
+  var existdata = existimage.data;
+  console.log(typeof(existdata));
+  for (var y = 0; y < height; y++) {
+	for (var x = 0; x < width; x++) {
+	  var pos = y * width + x;
+	  ctx.fillStyle = 'rgba(' + data[pos*4+0]
+						+ ',' + data[pos*4+1]
+						+ ',' + data[pos*4+2]
+						+ ',' + (data[pos*4+3]/255) + ')';
+	  ctx.fillRect(x , y , 1, 1);
+	}
+  }
+}
+
+
+
+
+
+var codeDesc ={1000:"Normal",
+1001:"Going Away",
+1002:"Protocol Error",
+1003:"Unsupported Data",
+1004:"Reserved",
+1005:"No Status Recvd- reserved",
+1006:"Abnormal Closure- reserved",
+1007:"Invalid frame payload data",
+1008:"Policy Violation",
+1009:"Message too big",
+1010:"Missing Extension",
+1011:"Internal Error",
+1012:"Service Restart",
+1013:"Try Again Later",
+1014:"Bad Gateway",
+1015:"TLS Handshake"};
+
+var readystateDesc ={0:"CONNECTING",
+1:"OPEN",
+2:"CLOSING",
+3:"CLOSED"};
+
+	
+// https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
+// small change Chrome > Blink, PhantomJS.
+var getBrowser = function() {
+	var isPhantom =  (navigator.userAgent == 'PhantomJS')
+	// Opera 8.0+
+	var isOpera = (!!window.opr && !!opr.addons) || !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
+	// Firefox 1.0+
+	var isFirefox = typeof InstallTrigger !== 'undefined';
+	// Safari 3.0+ "[object HTMLElementConstructor]"
+	var isSafari = /constructor/i.test(window.HTMLElement) || (function (p) { return p.toString() === "[object SafariRemoteNotification]"; })(!window['safari'] || (typeof safari !== 'undefined' && safari.pushNotification));
+	// Internet Explorer 6-11
+	var isIE = /*@cc_on!@*/false || !!document.documentMode;
+	// Edge 20+
+	var isEdge = !isIE && !!window.StyleMedia;
+	// Chrome 1+
+	var isChrome = !!window.chrome && !!window.chrome.webstore;
+	// Blink engine detection
+	var isBlink = (isChrome || isOpera) && !!window.CSS;
+	if(isPhantom){return "Phantom"};
+	if(isChrome){return "Chrome"};
+	if(isBlink){return "Blink"};
+	if(isEdge){return "Edge"};
+	if(isIE){return "Internet Explorer"};
+	if(isSafari){return "Safari"};
+	if(isFirefox){return "Firefox"};
+	if(isOpera){return "Opera"};
+	return "unknown";
+}
+</script>
+</body>
+</html>

--- a/test/browsertest2.html
+++ b/test/browsertest2.html
@@ -37,8 +37,8 @@ var width = 0;
 var height = 0;
 var widthstep = 30*2;
 var heightstep = 17*2;
-var maxwidth = 1920/4; // reduced because of slow Internet Explorer 11 canvas draw option.
-var maxheight = 1088/4;
+var maxwidth = 1920/2; 
+var maxheight = 1088/2;
 var recvbyteperpixel = 0;
 
 window.onload= function(){

--- a/test/functions_log_test.jl
+++ b/test/functions_log_test.jl
@@ -14,9 +14,9 @@ import WebSockets.WebSocketHandler
 import WebSockets.WebSocket
 import Base.print
 "Date time group string"
-dtg() = Dates.format(now(), "d u yy HH:MM:SS")
+dtg() = Dates.format(now(), "HH:MM:SS")
 """
-Console log with a heading, buffer and no mixing with output from other simultaneous tasks.
+Console log with a heading, buffer and no mixing with output from other tasks.
 We may, of course, be interrupting other tasks like stacktrace output.
 """
 function clog(args...)
@@ -25,6 +25,7 @@ function clog(args...)
     lock(STDERR)
     print(STDERR, String(take!(buf)))
     unlock(STDERR)
+    nothing
 end
 "Print with 'color' arguments Base.text_colors placed anywhere. Color_normal is set after the call is finished. "
 function pwc(io::IO, args...)

--- a/test/functions_open_browsers.jl
+++ b/test/functions_open_browsers.jl
@@ -119,8 +119,8 @@ function open_testpage(shortbrowsername)
         try
             if shortbrowsername == "phantomjs"
                 # Run enables text output of phantom messages in the REPL. In Windows  
-				# standalone REPL, run will freeze the main thread if not run async.
-				@async run(dmc)
+                # standalone REPL, run will freeze the main thread if not run async.
+                @async run(dmc)
             else
                 spawn(dmc)
             end
@@ -137,6 +137,7 @@ function open_all_browsers()
     openbrowsers = 0
     for b in brs
         openbrowsers += open_testpage(b)
+        sleep(8) # Reduce simultaneous connections to server. This is not a httpserver stress test. width:  
     end
     info("Out of google chrome, firefox, iexplore, safari and phantomjs, tried to spawn ", openbrowsers)
     openbrowsers

--- a/test/functions_open_browsers.jl
+++ b/test/functions_open_browsers.jl
@@ -82,7 +82,7 @@ function browser_path_windows(shortname)
     return ""
 end
 function launch_command(shortbrowsername)
-    url = "http://localhost:8080/browsertest.html"
+    url = "http://127.0.0.1:8080/browsertest.html"
     if Sys.is_windows()
         pt = browser_path_windows(shortbrowsername)
     else
@@ -117,7 +117,13 @@ function open_testpage(shortbrowsername)
         return false
     else
         try
-            spawn(dmc)
+            if shortbrowsername == "phantomjs"
+                # Run enables text output of phantom messages in the REPL. In Windows  
+				# standalone REPL, run will freeze the main thread if not run async.
+				@async run(dmc)
+            else
+                spawn(dmc)
+            end
         catch
             info("\tFailed to spawn " * shortbrowsername)
             return false

--- a/test/functions_server.jl
+++ b/test/functions_server.jl
@@ -16,14 +16,10 @@ function httphandle(request::Request, response::Response)
     if request.method=="GET"
         if request.resource =="/favicon.ico"
             response =  HttpServer.FileResponse(joinpath(@__DIR__, "favicon.ico"))
-            push!(response.headers, "Connection" => "close")
-
         elseif startswith(request.resource, "/browser")
             response =  HttpServer.FileResponse(joinpath(@__DIR__, splitdir(request.resource)[2]))
             if request.resource == "/browsertest.html"
                 n_responders += 1
-            else
-                push!(response.headers, "Connection" => "close")
             end
         else
             response = Response(404, "$id, can't serve $request.resource.")
@@ -32,6 +28,7 @@ function httphandle(request::Request, response::Response)
         response = Response(404, "$id, unexpected request.")
     end
     clog(id, response, "\n")
+    push!(response.headers, "Connection" => "close")
     return response
 end
 

--- a/test/functions_server.jl
+++ b/test/functions_server.jl
@@ -10,15 +10,23 @@ the types defined in HttpServer references to the functions. More commonly, anon
 are used.
 """
 function httphandle(request::Request, response::Response)
-    global noofresponders
+    global n_responders
     id = "server_functions.httphandle\t"
     clog(id, :cyan, request, "\n")
     if request.method=="GET"
         if request.resource =="/favicon.ico"
             response =  HttpServer.FileResponse(joinpath(@__DIR__, "favicon.ico"))
+            push!(response.headers, "Connection" => "close")
+
+        elseif startswith(request.resource, "/browser")
+            response =  HttpServer.FileResponse(joinpath(@__DIR__, splitdir(request.resource)[2]))
+            if request.resource == "/browsertest.html"
+                n_responders += 1
+            else
+                push!(response.headers, "Connection" => "close")
+            end
         else
-            response =  HttpServer.FileResponse(joinpath(@__DIR__, "browsertest.html"))
-            noofresponders += 1
+            response = Response(404, "$id, can't serve $request.resource.")
         end
     else
         response = Response(404, "$id, unexpected request.")
@@ -37,19 +45,15 @@ function websockethandle(wsrequest::Request, websocket::WebSocket)
     id = "server_functions.websockethandle\t"
     clog(id, :cyan, wsrequest, "\t", :yellow, websocket, "\n")
     if haskey(wsrequest.headers,"Sec-WebSocket-Protocol")
-        clog(id, "subprotocol spec: \n\t\t\t",
-                    :yellow, "Sec-WebSocket-Protocol => ", wsrequest.headers["Sec-WebSocket-Protocol"],"\n")
-        if     wsrequest.headers["Sec-WebSocket-Protocol"] == "websocket-testprotocol"
-            clog(id, "Websocket-testprotocol, calling handler\n")
+        if wsrequest.headers["Sec-WebSocket-Protocol"] == "websocket-testprotocol"
             ws_test_protocol(websocket)
-            clog(id, "Websocket-testprotocol, exiting handler\n")
+        elseif wsrequest.headers["Sec-WebSocket-Protocol"] == "websocket-test-binary"
+            ws_test_binary(websocket)
         else
-            clog(id, :red, "Unknown sub protocol let through WebSockets.jl, not responding further. \n")
+            clog(id, :red, "Unknown sub protocol let through, not responding further to #$(websocket.id). \n")
         end
     else
-        clog(id, "General websocket, calling handler\n")
         ws_general(websocket)
-        clog(id, "General websocket, exiting handler\n")
     end
     clog(id, "Exiting \n")
     nothing
@@ -60,6 +64,7 @@ function start_ws_server_async()
     id = "server_functions.start_ws_server\t"
     # Specify this subprotocol is to be let through to websockethandle:
     WebSockets.addsubproto("websocket-testprotocol")
+    WebSockets.addsubproto("websocket-test-binary")
     # Tell HttpHandler which functions to spawn when something happens.
     httpha = HttpHandler(httphandle)
     httpha.events["error"]  = ev_error
@@ -75,4 +80,27 @@ function start_ws_server_async()
     servertask = @async run( server, 8080)
     clog(id, "Server listening on localhost:8080\n")
     server
+end
+"Closes websockets and server; other existing sockets, if any, remain open."
+function closeall()
+    if isdefined(:WEBSOCKETS)
+        for va in values(WEBSOCKETS)
+            if isopen(va)
+                close(va)
+            end
+        end
+        if isdefined(:server)
+            close(server)
+        end
+    end
+end
+"Counts the number of open websocket in WEBSOCKETS dictionary"
+function count_open_websockets()
+    count = 0
+    for w in values(WEBSOCKETS)
+        if isopen(w)
+            count += 1
+        end
+    end
+    count
 end

--- a/test/functions_server.jl
+++ b/test/functions_server.jl
@@ -78,7 +78,7 @@ function start_ws_server_async()
     server = Server(httpha, wsh )
     clog(id, "Server to be started:\n", server )
     servertask = @async run( server, 8080)
-    clog(id, "Server listening on localhost:8080\n")
+    clog(id, "Server listening on 127.0.0.1:8080\n")
     server
 end
 "Closes websockets and server; other existing sockets, if any, remain open."

--- a/test/handler_functions_events.jl
+++ b/test/handler_functions_events.jl
@@ -6,6 +6,7 @@ end
 function ev_listen(port, args...)
     id = "events.ev_listen\t"
     #clog(id, :yellow, " from port ", :bold, port , :normal, " ", args..., " that was all I think. \n")
+    nothing
 end
 function ev_connect(client::Client, args...)
     id = "events.ev_connect\t"
@@ -17,7 +18,7 @@ function ev_close(client::Client, args...)
 end
 function ev_write(client::Client, response::Response)
     id = "events.ev_write\t"
-    #clog(id, "to ",:yellow, client , :bold, client , :normal, "\n", response, "\n")
+    clog(id, "to ", :yellow, :bold, client , :normal, "\n", response, "\n")
 end
 function ev_reset(client::Client, response::Response)
     id = "events.ev_reset\t"

--- a/test/handler_functions_websockets_general_test.jl
+++ b/test/handler_functions_websockets_general_test.jl
@@ -3,7 +3,7 @@
 
 
 function ws_general(ws::WebSockets.WebSocket)
-    id = "ws_general #$(ws.id)\t"
+    id = "ws_general     $(ws.id)\t"
     WEBSOCKETS[ws.id] = ws
     RECEIVED_WS_MSGS[ws.id] = String[]
     RECEIVED_WS_MSGS_LENGTH[ws.id] = Vector{Int64}()
@@ -41,18 +41,14 @@ end
 Listens for the next websocket message
 """
 function wsmsg_listen(ws::WebSockets.WebSocket)
-    id = "wsmsg_listen #$(ws.id)\t"
+    id = "wsmsg_listen     $(ws.id)\t"
     clog(id,  " Listening...\n")
     stri = ""
     data = Vector{UInt8}()
     t = 0.0
     allocbytes = 0
     try
-        # Holding here. Cleanup code could work with InterruptException and Base.throwto.
-        # This is not considered necessary for the test (and doesn't really work well).
-        # So, this may continue running after the test is finished.
-        push!(RECEIVED_WS_MSGS_TIME[ws.id], t)
-        push!(RECEIVED_WS_MSGS_ALLOCATED[ws.id], allocbytes)
+        # Holding here. 
         data , t, allocbytes = @timed ws|> read
         push!(RECEIVED_WS_MSGS_LENGTH[ws.id], length(data))
         push!(RECEIVED_WS_MSGS_TIME[ws.id], t)

--- a/test/handler_functions_websockets_general_test.jl
+++ b/test/handler_functions_websockets_general_test.jl
@@ -6,17 +6,27 @@ function ws_general(ws::WebSockets.WebSocket)
     id = "ws_general #$(ws.id)\t"
     WEBSOCKETS[ws.id] = ws
     RECEIVED_WS_MSGS[ws.id] = String[]
-    clog(id,  " Entering to read websocket.\n")
-    stri = wsmsg_general(ws)
-    clog(id,  " Send a message\n")
-    push!(RECEIVED_WS_MSGS[ws.id], stri)
-    writeto(ws.id, "Here, have a message!")
-    clog(id,  " Continue to listen for message\n")
+    RECEIVED_WS_MSGS_LENGTH[ws.id] = Vector{Int64}()
+    RECEIVED_WS_MSGS_TIME[ws.id] = Vector{Float64}()
+    RECEIVED_WS_MSGS_ALLOCATED[ws.id] = Vector{Int64}()
+    sendmsg = "Welcome, general websocket. Our ref.: $(ws.id)"
+    clog(id,  " Send: $sendmsg\n")
     while isopen(ws)
-        stri = wsmsg_general(ws)
+        stri = wsmsg_listen(ws)
         push!(RECEIVED_WS_MSGS[ws.id], stri)
+        clog(id, "Received: \n", :yellow, :bold, stri, "\n")
+        if startswith(stri, "Ping me!")
+            send_ping(ws)
+            sendmsg = "Your browser just got pinged (and presumably ponged back). Our ref.: $(ws.id)"
+            clog(id,  " Sending: $sendmsg\n")
+            writeto(ws.id, sendmsg)
+        elseif startswith(stri, "ws1 echo: Your browser just got pinged ")
+                sendmsg = "Close, wait, and navigate to: browsertest2.html"
+            clog(id,  " Sending: $sendmsg\n")
+            writeto(ws.id, sendmsg)
+        end
     end
-    clog(id, "Websocket was closed; exiting read loop\n")
+    clog(id, "Websocket $(ws.id) was closed; exits handler.\n")
     nothing
 end
 
@@ -24,22 +34,30 @@ function writeto(wsid::Int, message)
     if haskey(WEBSOCKETS, wsid)
         write(WEBSOCKETS[wsid], message)
     end
+    return nothing
 end
 
 """
 Listens for the next websocket message
 """
-function wsmsg_general(ws::WebSockets.WebSocket)
-    id = "wsmsg_general #$(ws.id)\t"
-    clog(id,  " Entering to read websocket.\n")
+function wsmsg_listen(ws::WebSockets.WebSocket)
+    id = "wsmsg_listen #$(ws.id)\t"
+    clog(id,  " Listening...\n")
     stri = ""
+    data = Vector{UInt8}()
+    t = 0.0
+    allocbytes = 0
     try
         # Holding here. Cleanup code could work with InterruptException and Base.throwto.
         # This is not considered necessary for the test (and doesn't really work well).
         # So, this may continue running after the test is finished.
-        stri = ws|> read  |> String
-        clog(id, "Received: \n", :yellow, :bold, stri, "\n")
-        # push!
+        push!(RECEIVED_WS_MSGS_TIME[ws.id], t)
+        push!(RECEIVED_WS_MSGS_ALLOCATED[ws.id], allocbytes)
+        data , t, allocbytes = @timed ws|> read
+        push!(RECEIVED_WS_MSGS_LENGTH[ws.id], length(data))
+        push!(RECEIVED_WS_MSGS_TIME[ws.id], t)
+        push!(RECEIVED_WS_MSGS_ALLOCATED[ws.id], allocbytes)
+        stri = data |> String
     catch e
         if typeof(e) == WebSockets.WebSocketClosedError
             clog(id, :green, " Websocket was or is being closed.\n")
@@ -51,7 +69,6 @@ function wsmsg_general(ws::WebSockets.WebSocket)
             end
         end
     end
-
-    clog(id, "Exiting\n")
     return stri
 end
+return nothing

--- a/test/handler_functions_websockets_subprotocol_test.jl
+++ b/test/handler_functions_websockets_subprotocol_test.jl
@@ -3,7 +3,7 @@
 
 
 function ws_test_protocol(ws::WebSockets.WebSocket)
-    id = "ws_test_protocol #$(ws.id)\t"
+    id = "ws_test_protocol $(ws.id)\t"
     WEBSOCKETS[ws.id] = ws
     WEBSOCKETS_SUBPROTOCOL[ws.id] = ws
     WEBSOCKETS[ws.id] = ws
@@ -32,7 +32,7 @@ function ws_test_protocol(ws::WebSockets.WebSocket)
 end
 
 function ws_test_binary(ws::WebSockets.WebSocket)
-    id = "ws_test_binary #$(ws.id)\t"
+    id = "ws_test_binary $(ws.id)\t"
     WEBSOCKETS[ws.id] = ws
     WEBSOCKETS_BINARY[ws.id] = ws
     RECEIVED_WS_MSGS_LENGTH[ws.id] = Vector{Int64}()

--- a/test/handler_functions_websockets_subprotocol_test.jl
+++ b/test/handler_functions_websockets_subprotocol_test.jl
@@ -1,38 +1,102 @@
 #     These functions deal with specified websocket protocols.
 #      Included in server_functions.jl
 
+using Base.Profile
 function ws_test_protocol(ws::WebSockets.WebSocket)
     id = "ws_test_protocol #$(ws.id)\t"
     WEBSOCKETS[ws.id] = ws
     WEBSOCKETS_SUBPROTOCOL[ws.id] = ws
+    WEBSOCKETS[ws.id] = ws
     RECEIVED_WS_MSGS[ws.id] = String[]
-    clog(id,  " Entering to read websocket.\n")
-    stri = wsmsg_general(ws)
-    clog(id,  " Send a message\n")
-    push!(RECEIVED_WS_MSGS[ws.id], stri)
-    writeto(ws.id, "Here, have a message!")
-    clog(id,  " Continue to listen for message\n")
+    RECEIVED_WS_MSGS_LENGTH[ws.id] = Vector{Int64}()
+    RECEIVED_WS_MSGS_TIME[ws.id] = Vector{Float64}()
+    RECEIVED_WS_MSGS_ALLOCATED[ws.id] = Vector{Int64}()
+    sendmsg = "Special welcome. Our ref.: $(ws.id)"
+    clog(id,  " Sending: $sendmsg\n")
+    writeto(ws.id, sendmsg)
     while isopen(ws)
-        stri = wsmsg_testprotocol(ws)
+        stri = wsmsg_listen(ws)
         push!(RECEIVED_WS_MSGS[ws.id], stri)
+        clog(id, "Received: \n", :yellow, :bold, stri, "\n")
+        if startswith(stri, "Ping me!")
+            sendmsg = "No ping for you. Our ref.: $(ws.id). Will close on next received message."
+            clog(id,  " Sending: $sendmsg\n")
+            writeto(ws.id, sendmsg)
+        elseif startswith(stri, "ws2 echo: No ping for you.")
+            clog(id,  "Closing from server\n")
+            close(ws)
+        end
     end
-    clog(id, "Websocket was closed; exiting read loop\n")
+    clog(id, "Websocket on subprotocol $(ws.id) was closed; exits handler.\n")
     nothing
 end
 
+function ws_test_binary(ws::WebSockets.WebSocket)
+    id = "ws_test_binary #$(ws.id)\t"
+    WEBSOCKETS[ws.id] = ws
+    WEBSOCKETS_BINARY[ws.id] = ws
+    RECEIVED_WS_MSGS_LENGTH[ws.id] = Vector{Int64}()
+    RECEIVED_WS_MSGS_TIME[ws.id] = Vector{Float64}()
+    RECEIVED_WS_MSGS_ALLOCATED[ws.id] = Vector{Int64}()
+    width = Int16(0)
+    height = Int16(0)
+    byteperpixel = Int16(4)
+    ub = 0
+    clog(id,  " Handler is running \n")
+    while isopen(ws)
+        data = wsmsg_listen_binary(ws)
+        ub = length(data)
+        if ub == 6
+            # Don't do this like this at home perhaps. Dealing with net endianness by reversing the order of bytes AND arguments..
+            byteperpixel, height, width = reinterpret(Int16, reverse(data))
+            clog(id, "Received 6 bytes = 3xInt16 custom header: \n\t\t\t\t\t"
+                    , :yellow, " height: ", :bold, height
+                    , :normal, :yellow, " width: ", :bold, width
+                    , :normal, :yellow, " byteperpixel: ", byteperpixel, "\n")
+        elseif ub == Int(width) * height * byteperpixel
+            clog(id, "Received image data for manipulation, ", div(length(data), 1024),  " kB\n")
+            tic()
+            ired =  1:4:ub
+            igreen =  2:4:ub
+            iblue =  3:4:ub
+            ialpha = 4:4:ub
+            itpquarter = 1:div(ub,4)
+            fill!(view(data, ialpha), 0xee)
+            fill!(view(data, iblue), 0xff)
+            fill!(view(data, intersect(itpquarter, ired)), 0x88)
+            rand!(view(data, ired), [0x00, 0x88, 0xff])
+            hedata = UInt16.([height, width, 4])
+            clog(id, "Manipulated image and made ready in $(toq()*1000) ms. \n\t\tSending header, then image.\n")    
+            writeto(ws.id,  reinterpret(UInt8, hedata))
+            writeto(ws.id,  data)
+        else
+            clog(id, "Received unexpected data: \t", :yellow, :bold, length(data), "-element ", typeof(data), "\n")
+            clog(id, "expected length: ",  Int(width) * height * byteperpixel
+                    , :yellow, " height: ", :bold, height
+                    , :normal, :yellow, " width: ", :bold, width
+                    , :normal, :yellow, " byteperpixel: ", byteperpixel, "\n")
+        end
+    end
+    clog(id, "Websocket on subprotocol $(ws.id) was closed; exits handler.\n")
+    nothing
+end
 """
-Listens for the next websocket message.
+Listens for the next binary websocket message
 """
-function wsmsg_testprotocol(ws::WebSockets.WebSocket)
-    id = "wsmsg_testprotocol #$(ws.id)\t"
-    clog(id,  " Entering to read websocket.\n")
-    stri = ""
+function wsmsg_listen_binary(ws::WebSockets.WebSocket)
+    id = "wsmsg_listen_binary $(ws.id)\t"
+    clog(id,  " Binary listening...\n")
+    data = Vector{UInt8}()
+    t = 0.0
+    allocbytes = 0
     try
         # Holding here. Cleanup code could work with InterruptException and Base.throwto.
         # This is not considered necessary for the test (and doesn't really work well).
         # So, this may continue running after the test is finished.
-        stri = ws|> read  |> String
-        clog(id, "Received: \n", :yellow, :bold, stri, "\n")
+        data , t, allocbytes = @timed ws|> read
+        push!(RECEIVED_WS_MSGS_LENGTH[ws.id], length(data))
+        push!(RECEIVED_WS_MSGS_TIME[ws.id], t)
+        push!(RECEIVED_WS_MSGS_ALLOCATED[ws.id], allocbytes)
     catch e
         if typeof(e) == WebSockets.WebSocketClosedError
             clog(id, :green, " Websocket was or is being closed.\n")
@@ -44,11 +108,7 @@ function wsmsg_testprotocol(ws::WebSockets.WebSocket)
             end
         end
     end
-    clog(id, "Exiting\n")
-    return stri
+    return data
 end
-
-
-
 
 return nothing

--- a/test/handler_functions_websockets_subprotocol_test.jl
+++ b/test/handler_functions_websockets_subprotocol_test.jl
@@ -1,7 +1,7 @@
 #     These functions deal with specified websocket protocols.
 #      Included in server_functions.jl
 
-using Base.Profile
+
 function ws_test_protocol(ws::WebSockets.WebSocket)
     id = "ws_test_protocol #$(ws.id)\t"
     WEBSOCKETS[ws.id] = ws


### PR DESCRIPTION
```
mod:   test/browsertest.jl      Ws conversation is now left fully to browsers.
                                Prints a performance summary at the end.
mod:   test/browsertest.html    Less code duplication, simplified conversation.
                                Navigates to browsertest2.html when exitmsg is received.
new:   test/browsertest2.html   Adds one binary socket. Sends binary image data with increasing
                                image size. Displays received images. Logs conversation on page.
mod:   test/functions_log_test.jl                   clog now returns nothing, for type stability.
mod:   test/functions_server.jl                     Also serves browsertest2.html. The served
                                                    response specifies the http socket close after.
mod:   test/handler_functions_events.jl             Removed accidentally returned string, ev_listen.
mod:   test/functions_open_browsers.jl              PhantomJS is now 'run' async, not spawned. For console
                                                    feedback.
mod:   test/handler_functions_websockets_general_test.jl        Added text message performance logging,
                                                                changed ws test conversation. Include a
                                                                request for a ping from browser (pongs are
                                                                not output).
mod:   test/handler_functions_websockets_subprotocol_test.jl    Added performance logging,
                                                                changed ws test conversation. Added binary
                                                                handler, which modifies images before sending
                                                                back to browser.
```