### PR TITLE
Keyword argument constructors, show types, README update

### DIFF
--- a/logutils/logutils_ws.jl
+++ b/logutils/logutils_ws.jl
@@ -339,15 +339,15 @@ end
 function _limlen(data::Union{Vector{UInt8}, Vector{Float64}})
     le = length(data)
     maxlen = 12 # elements, not characters
-	if le <  maxlen
-		return  string(data)
+    if le <  maxlen
+        return  string(data)
     else
         adds =  " ..... "
         addlen = 2
         truncat = 2 * div(maxlen, 3)
         tail = maxlen - truncat - addlen - 1
         return string(data[1:truncat])[1:end-1] * adds * string(data[end-tail:end])[7:end]
-	end
+    end
 end
 
 
@@ -358,12 +358,12 @@ _tg() = Dates.Time(now())
 
 "For use in show(io::IO, obj) methods. Hook into this logger's dispatch mechanism."
 function directto_abstractdevice(io::IO, obj)
-	if isa(io, ColorDevices)
-		buf = ColorDevice(IOBuffer())
-	else
-		buf = BlackWDevice(IOBuffer())
-	end
-	_show(buf, obj)
+    if isa(io, ColorDevices)
+        buf = ColorDevice(IOBuffer())
+    else
+        buf = BlackWDevice(IOBuffer())
+    end
+    _show(buf, obj)
     write(io, take!(buf.s))
     nothing
 end

--- a/src/show_ws.jl
+++ b/src/show_ws.jl
@@ -130,7 +130,7 @@ function Base.show(io::IO, sws::ServerWS)
             print(io, "IOBuffer():")
         elseif sws.logger isa IOStream
             print(io, sws.logger.name, ":")
-        elseif sws.logger isa Base.DevNull
+        elseif sws.logger == devnull
         else
             print(io, nameof(typeof(sws.logger)), ":")
         end

--- a/src/show_ws.jl
+++ b/src/show_ws.jl
@@ -1,14 +1,14 @@
 import Base.show
-# Long form, as in display(ws) or REPL ws enter
+import Base.method_argnames
+# Long form, as in display(ws) or REPL: ws enter
 function Base.show(io::IO, ::MIME"text/plain", ws::WebSocket{T}) where T
     ioc = IOContext(io, :wslog => true)
     print(ioc, "WebSocket{", nameof(T), "}(", ws.server ? "server, " : "client, ")
     _show(ioc, ws.state)
     print(ioc, "): ")
     _show(ioc, ws.socket)
-    nothing
 end
-# Short form, as in print(stdout, ws)
+# Short form with state, as in print(stdout, ws)
 function Base.show(io::IO, ws::WebSocket{T}) where T
     ioc = IOContext(io, :compact=>true, :wslog => true)
     if T == TCPSocket
@@ -19,21 +19,16 @@ function Base.show(io::IO, ws::WebSocket{T}) where T
     print(ioc, ws.server ? "server, " : "client, ")
     _show(ioc, ws.state)
     print(ioc,  ")")
-    nothing
 end
 
-# Short form, as in Juno / Atom
-# In documentation (and possible future version)::MIME"application/prs.juno.inline"
+# The default Juno / Atom display works nicely with standard output
 Base.show(io::IO, ::MIME"application/prs.juno.inline", ws::WebSocket) = Base.show(io, ws)
-Base.show(io::IO, ::MIME"application/juno+inline", ws::WebSocket) = Base.show(io, ws)
-
 
 
 # A Base.show method is already defined by @enum
 function _show(io::IO, state::ReadyState)
     kwargs, msg = _uv_status_tuple(state)
     printstyled(io, msg; kwargs...)
-    nothing
 end
 
 function _show(io::IO, stream::Base.LibuvStream)
@@ -46,9 +41,30 @@ function _show(io::IO, stream::Base.LibuvStream)
         if !(stream isa Servers.UDPSocket)
             nba = bytesavailable(stream.buffer)
             nba > 0 && print(io, ", ", nba, " bytes")
+            nothing
         end
     end
-    nothing
+end
+function _show(io::IO, stream::IOStream)
+    # To avoid accidental type piracy, a double check:
+    if !get(IOContext(io), :wslog, false)
+        show(io, stream)
+    else
+        kwargs, msg = _uv_status_tuple(stream)
+        printstyled(io, msg; kwargs...)
+    end
+end
+function _show(io::IO, buf::Base.GenericIOBuffer)
+    # To avoid accidental type piracy, a double check:
+    if !get(IOContext(io), :wslog, false)
+        show(io, buf)
+    else
+        kwargs, msg = _uv_status_tuple(buf)
+        printstyled(io, msg; kwargs...)
+        nba = buf.size
+        nba > 0 && print(io, ", ", nba, " bytes")
+        nothing
+    end
 end
 
 "For colorful printing"
@@ -85,8 +101,8 @@ function _uv_status_tuple(x)
         (color = :red,), "invalid status"
     end
 end
-function _uv_status_tuple(bs::Base.BufferStream)
-    if bs.is_open
+function _uv_status_tuple(bs::Union{Base.BufferStream, IOStream, Base.GenericIOBuffer})
+    if isopen(bs)
         (color = :green,), "✓"   # "open"
     else
         (color = :red,), "✘" #"closed"
@@ -100,4 +116,72 @@ function _uv_status_tuple(status::ReadyState)
     elseif status == CLOSED
         (color = :red,), "CLOSED"
     end
+end
+
+### ServerWS
+function Base.show(io::IO, sws::ServerWS)
+    print(io, ServerWS, "(handler=")
+    _show(io, sws.handler.func)
+    print(io, ", wshandler=")
+    _show(io, sws.wshandler.func)
+    if sws.logger != stdout
+        print(io, ", logger=")
+        if sws.logger isa Base.GenericIOBuffer
+            print(io, "IOBuffer():")
+        elseif sws.logger isa IOStream
+            print(io, sws.logger.name, ":")
+        elseif sws.logger isa Base.DevNull
+        else
+            print(io, nameof(typeof(sws.logger)), ":")
+        end
+        _show(IOContext(io, :wslog=>true), sws.logger)
+    end
+    if sws.options != WebSockets.ServerOptions()
+        print(io, ", ")
+        show(IOContext(io, :wslog=>true), sws.options)
+    end
+    print(io, ")")
+    if isready(sws.in)
+        printstyled(io, ".in:", color= :yellow)
+        print(io, sws.in, " ")
+    end
+    if isready(sws.out)
+        printstyled(io, ".out:", color= :yellow)
+        print(io, sws.out, " ")
+    end
+end
+
+
+function Base.show(io::IO, swo::WebSockets.ServerOptions)
+    hidetype = get(IOContext(io), :wslog, false)
+    fina = fieldnames(ServerOptions)
+    hidetype || print(io, ServerOptions, "(")
+    for field in fina
+        fiva = getfield(swo, field)
+        if fiva != nothing
+            print(io, field, "=")
+            print(io, fiva)
+            if field != last(fina)
+                print(io, ", ")
+            end
+        end
+    end
+    hidetype || print(io, ")")
+    nothing
+end
+
+
+
+
+_show(io::IO, x) = show(io, x)
+function _show(io::IO, f::Function)
+   m = methods(f)
+   if length(m) > 1
+       print(io, f, " has ", length(m), " methods: ")
+       Base.show_method_table(io, m, 4, false)
+   else
+       method = first(m)
+       argnames = join(method_argnames(method)[2:end], ", ")
+       print(io, method.name, "(", argnames, ")")
+   end
 end

--- a/test/show_test.jl
+++ b/test/show_test.jl
@@ -223,11 +223,12 @@ output = String(take!(io))
 
 # with loggers
 sws = ServerWS(handler= h, wshandler= w, logger = stderr)
-io = IOBuffer()
+io = IOBuffer()l
 show(io, sws)
 output = String(take!(io))
 @test output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=TTY:✓)" ||
-    output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=PipeEndpoint():✓)"
+    output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=PipeEndpoint():✓)" ||
+    println(stderr, "Test output :229= ", output)
 fi = open("temptemp", "w+")
 sws = ServerWS(h, w, fi)
 io = IOBuffer()

--- a/test/show_test.jl
+++ b/test/show_test.jl
@@ -227,7 +227,7 @@ io = IOBuffer()
 show(io, sws)
 output = String(take!(io))
 @test output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=TTY:✓)" ||
-    "ServerWS(handler=h(r), wshandler=w(ws, r), logger=PipeEndpoint():✓)"
+    output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=PipeEndpoint():✓)"
 fi = open("temptemp", "w+")
 sws = ServerWS(h, w, fi)
 io = IOBuffer()

--- a/test/show_test.jl
+++ b/test/show_test.jl
@@ -228,7 +228,7 @@ show(io, sws)
 output = String(take!(io))
 @test output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=TTY:✓)" ||
     output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=PipeEndpoint():✓)" ||
-    println(stderr, "Test output :229= ", output)
+    output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=PipeEndpoint:✓)"
 fi = open("temptemp", "w+")
 sws = ServerWS(h, w, fi)
 io = IOBuffer()

--- a/test/show_test.jl
+++ b/test/show_test.jl
@@ -142,11 +142,10 @@ _show(io, iob)
 output = String(take!(io.io))
 @test output == "IOBuffer(data=UInt8[...], readable=true, writable=true, seekable=true, append=false, size=0, maxsize=Inf, ptr=1, mark=-1)"
 
-dnull = Base.DevNull()
 io = IOContext(IOBuffer())
-_show(io, dnull)
+_show(io, devnull)
 output = String(take!(io.io))
-@test output == "Base.DevNull()"
+@test output == "Base.DevNull()" || output == "Base.DevNullStream()"
 
 
 
@@ -242,11 +241,12 @@ output = String(take!(io))
 @test output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=<file temptemp>:✘)"
 
 
-sws = ServerWS(handler= h, wshandler= w, logger = Base.DevNull())
+sws = ServerWS(handler= h, wshandler= w, logger = devnull)
 io = IOBuffer()
 show(io, sws)
 output = String(take!(io))
-@test output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=Base.DevNull())"
+@test output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=Base.DevNull())" ||
+    output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=Base.DevNullStream())"
 
 sws = ServerWS(handler= h, wshandler= w, logger = IOBuffer())
 io = IOBuffer()

--- a/test/show_test.jl
+++ b/test/show_test.jl
@@ -223,7 +223,7 @@ output = String(take!(io))
 
 # with loggers
 sws = ServerWS(handler= h, wshandler= w, logger = stderr)
-io = IOBuffer()l
+io = IOBuffer()
 show(io, sws)
 output = String(take!(io))
 @test output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=TTY:✓)" ||

--- a/test/show_test.jl
+++ b/test/show_test.jl
@@ -226,8 +226,8 @@ sws = ServerWS(handler= h, wshandler= w, logger = stderr)
 io = IOBuffer()
 show(io, sws)
 output = String(take!(io))
-@test output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=TTY:✓)"
-
+@test output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=TTY:✓)" ||
+    "ServerWS(handler=h(r), wshandler=w(ws, r), logger=PipeEndpoint():✓)"
 fi = open("temptemp", "w+")
 sws = ServerWS(h, w, fi)
 io = IOBuffer()

--- a/test/show_test.jl
+++ b/test/show_test.jl
@@ -1,10 +1,13 @@
 using Test
 import Base:    C_NULL, LibuvStream, GenericIOBuffer, BufferStream
 import Sockets: UDPSocket, @ip_str, send, recvfrom, TCPSocket
+
 using WebSockets
+
 import WebSockets:_show,
     ReadyState,
-    _uv_status_tuple
+    _uv_status_tuple,
+    Response
 mutable struct DummyStream <: LibuvStream
     buffer::GenericIOBuffer
     status::Int
@@ -35,6 +38,28 @@ let kws = [], msgs =[]
     @test msgs == ["CONNECTED", "CLOSING", "CLOSED"]
 end
 
+let kws = [], msgs =[]
+    fi = open("temptemp", "w+")
+    kwarg, msg = _uv_status_tuple(fi)
+    push!(kws, kwarg)
+    push!(msgs, msg)
+    close(fi)
+    rm("temptemp")
+    kwarg, msg = _uv_status_tuple(fi)
+    push!(kws, kwarg)
+    push!(msgs, msg)
+    @test kws == [(color = :green,), (color = :red,)]
+    @test msgs == ["✓", "✘"]
+end
+
+
+fi = open("temptemp", "w+")
+io = IOBuffer()
+_show(IOContext(io, :wslog=>true), fi)
+close(fi)
+rm("temptemp")
+output = String(take!(io))
+@test output == "✓"
 
 ds = DummyStream(IOBuffer(), 0, 0x00000001)
 io = IOBuffer()
@@ -104,6 +129,26 @@ output = String(take!(io.io))
 # No reporting of zero bytes
 @test output == "\e[34muninit\e[39m"
 
+iob = IOBuffer()
+write(iob, "123")
+io = IOContext(IOBuffer(), :color => true, :wslog=>true)
+_show(io, iob)
+output = String(take!(io.io))
+@test output == "\e[32m✓\e[39m, 3 bytes"
+
+iob = IOBuffer()
+io = IOContext(IOBuffer())
+_show(io, iob)
+output = String(take!(io.io))
+@test output == "IOBuffer(data=UInt8[...], readable=true, writable=true, seekable=true, append=false, size=0, maxsize=Inf, ptr=1, mark=-1)"
+
+dnull = Base.DevNull()
+io = IOContext(IOBuffer())
+_show(io, dnull)
+output = String(take!(io.io))
+@test output == "Base.DevNull()"
+
+
 
 # Short form, as in print(stdout, ws)
 ws = WebSocket(BufferStream(), true)
@@ -125,7 +170,6 @@ show(io, ws)
 output = String(take!(io.io))
 @test output == "WebSocket{BufferStream}(client, \e[32mCONNECTED\e[39m)"
 
-
 ws = WebSocket(TCPSocket(), false)
 io = IOContext(IOBuffer(), :color => true)
 show(io, ws)
@@ -139,14 +183,6 @@ io = IOContext(IOBuffer(), :color => true)
 show(io, "application/prs.juno.inline", ws)
 output = String(take!(io.io))
 @test output == "WebSocket(client, \e[32mCONNECTED\e[39m)"
-
-#short form for Atom / Juno
-ws = WebSocket(TCPSocket(), false)
-io = IOContext(IOBuffer(), :color => true)
-show(io, "application/juno+inline", ws)
-output = String(take!(io.io))
-@test output == "WebSocket(client, \e[32mCONNECTED\e[39m)"
-
 
 # Long form, as in print(stdout, ws)
 ws = WebSocket(TCPSocket(), true)
@@ -162,3 +198,58 @@ io = IOContext(IOBuffer(), :color => true)
 show(io, "text/plain", ws)
 output = String(take!(io.io))
 @test output == "WebSocket{BufferStream}(client, \e[32mCONNECTED\e[39m): \e[32m✓\e[39m, 2 bytes"
+
+### For testing Base.show(ServerWS)
+h(r) = Response(200)
+w(ws, r) = nothing
+io = IOBuffer()
+_show(io, h)
+output = String(take!(io))
+@test output == "h(r)"
+
+_show(io, x-> 2x)
+output = String(take!(io))
+@test output[1] == '#'
+
+
+sws = ServerWS(h, w)
+show(io, sws)
+output = String(take!(io))
+@test output == "ServerWS(handler=h(r), wshandler=w(ws, r))"
+
+sws = ServerWS(h, w,  ratelimit = 1 // 1)
+show(io, sws)
+output = String(take!(io))
+@test output == "ServerWS(handler=h(r), wshandler=w(ws, r), readtimeout=180.0, ratelimit=1//1, support100continue=true, logbody=true)"
+
+# with loggers
+sws = ServerWS(handler= h, wshandler= w, logger = stderr)
+io = IOBuffer()
+show(io, sws)
+output = String(take!(io))
+@test output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=TTY:✓)"
+
+fi = open("temptemp", "w+")
+sws = ServerWS(h, w, fi)
+io = IOBuffer()
+_show(io, sws)
+output = String(take!(io))
+@test output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=<file temptemp>:✓)"
+close(fi)
+_show(io, sws)
+rm("temptemp")
+output = String(take!(io))
+@test output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=<file temptemp>:✘)"
+
+
+sws = ServerWS(handler= h, wshandler= w, logger = Base.DevNull())
+io = IOBuffer()
+show(io, sws)
+output = String(take!(io))
+@test output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=Base.DevNull())"
+
+sws = ServerWS(handler= h, wshandler= w, logger = IOBuffer())
+io = IOBuffer()
+show(io, sws)
+output = String(take!(io))
+@test output == "ServerWS(handler=h(r), wshandler=w(ws, r), logger=IOBuffer():✓)"

--- a/test/throttling_test.jl
+++ b/test/throttling_test.jl
@@ -80,7 +80,8 @@ put!(serverWS.in, "closeit")
 serverWS =  ServerWS(  (r) -> WebSockets.Response(200, "OK"),
                        (r, ws) -> nothing,
                        sslconfig = SSLConfig())
-tas = @async WebSockets.serve(serverWS, IPA, THISPORT)
+
+tas = @async WebSockets.serve(serverWS, host = IPA, port =THISPORT)
 const URL10 = "https://$IPA:$THISPORT"
 @test_throws WebSockets.HTTP.IOExtras.IOError WebSockets.HTTP.request("GET", URL10)
 const WSSURI = "wss://$IPA:$THISPORT"

--- a/test/throttling_test.jl
+++ b/test/throttling_test.jl
@@ -52,7 +52,9 @@ countconnections(1//1, Millisecond(500))
 close(tcpserver)
 
 @info "Make http request to a server with specified ratelimit 1 new connections // 1 second"
-const THISPORT = 8091
+if !@isdefined(THISPORT)
+    const THISPORT = 8091
+end
 const IPA = "127.0.0.1"
 const URL9 = "http://$IPA:$THISPORT"
 serverWS =  ServerWS(  (r) -> WebSockets.Response(200, "OK"),


### PR DESCRIPTION
modified:   README.md	Example with (suppressed) output
modified:   src/HTTP.jl Keyword arguments: ServerWS, serve
modified:   src/show_ws.jl  Drop "application/juno+inline"
                            Base.show for ServerWS
modified:   test/show_test.jl Test all this
modified:   test/throttling_test.jl Test serve keywords

Refer issue #128 