### PR TITLE
Stricter ad-hoc tests for timeout up to 8192 s / 42 simultaneous.

### DIFF
--- a/test/timeout/limited life websockets.html
+++ b/test/timeout/limited life websockets.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html>
+  <head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<title>WS timeout test</title>
+</head>
+<body>
+<p>Limited life websockets, testing against unwanted timeouts.
+</p>
+<ul><li id="1s_timeout">Timeout 1 s</li></ul>
+<ul><li id="2s_timeout">Timeout 2 s</li></ul>
+<ul><li id="4s_timeout">Timeout 4 s</li></ul>
+<ul><li id="8s_timeout">Timeout 8 s</li></ul>
+<ul><li id="16s_timeout">Timeout 16 s</li></ul>
+<ul><li id="32s_timeout">Timeout 32 s</li></ul>
+<ul><li id="64s_timeout">Timeout 64 s</li></ul>
+<ul><li id="128s_timeout">Timeout 128 s</li></ul>
+<ul><li id="256s_timeout">Timeout 256 s</li></ul>
+<ul><li id="512s_timeout">Timeout 512 s</li></ul>
+<ul><li id="1024s_timeout">Timeout 1024 s</li></ul>
+<ul><li id="2048s_timeout">Timeout 2048 s</li></ul>
+<ul><li id="4096s_timeout">Timeout 4096 s</li></ul>
+<ul><li id="8192s_timeout">Timeout 8192 s</li></ul>
+
+<p id = "init"></p>
+<script>
+
+window.onload= function(){
+	plog("init", "<p>:window.onload</p>")
+	for(var i = 0; i < 14; i++){
+			var sec = Math.pow(2, i)
+			addtimeoutwebsocket(sec)
+		}
+	}
+
+// log to DOM element with id ws
+function plog(ws, shtm){
+	document.getElementById(ws).innerHTML += shtm
+	}
+
+const sleep = (ms) => {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function addtimeoutwebsocket(s_timeout){
+	let wsuri = document.URL.replace("http:","ws:")
+	let ws = new WebSocket(wsuri)
+	let instancename = s_timeout + "s_timeout" 
+	ws.mynam = instancename
+	ws.onclose = function(e){
+		plog(e.target.mynam, "<p>: " + e.target.mynam + ".onclose:" +
+			"wasClean: " + e.wasClean + ";  " +
+			"code: " + e.code + ";  " + codeDesc[e.code] + ";  " +
+			"reason: " + e.reason + ";  " +
+			"<br>&nbsp;&nbsp;Websocket state is now " + e.target.readyState +
+			" " + readystateDesc[e.target.readyState] + ".</p>")
+		}
+	ws.onerror = function(e){
+		plog(e.target.mynam, "<p>: " + e.target.mynam + ".onerror: " +
+			"<br>&nbsp;&nbsp;Websocket state is now " + e.target.readyState +
+			" " + readystateDesc[e.target.readyState] + ".</p>")
+		}
+	ws.onopen = function(e){
+		plog(e.target.mynam, "<p>: " + e.target.mynam + ".onopen: " +
+			"<br>&nbsp;&nbsp;Websocket state is now " + e.target.readyState +
+			" " + readystateDesc[e.target.readyState]
+			)
+		ws.send(instancename)
+		}
+	ws.onmessage = function (e){
+		var msg = e.data
+		plog(e.target.mynam, "<p>Received: " + msg)
+	}
+	plog(instancename, "<p>" + instancename + " created.</p>")
+	sleep(1000*s_timeout).then(() => {
+		var msg = s_timeout + " seconds are up!"
+		plog(instancename, "<p>: " + msg + "</p>")
+		ws.close(1000, msg)
+	})
+	return ws
+} // addtimeoutwebsocket
+
+
+var codeDesc ={1000:"Normal",
+1001:"Going Away",
+1002:"Protocol Error",
+1003:"Unsupported Data",
+1004:"Reserved",
+1005:"No Status Recvd- reserved",
+1006:"Abnormal Closure- reserved",
+1007:"Invalid frame payload data",
+1008:"Policy Violation",
+1009:"Message too big",
+1010:"Missing Extension",
+1011:"Internal Error",
+1012:"Service Restart",
+1013:"Try Again Later",
+1014:"Bad Gateway",
+1015:"TLS Handshake"}
+
+var readystateDesc ={0:"CONNECTING",
+1:"OPEN",
+2:"CLOSING",
+3:"CLOSED"}
+</script>
+</body>
+</html>

--- a/test/timeout/timeout.jl
+++ b/test/timeout/timeout.jl
@@ -1,0 +1,82 @@
+# This opens 14*3 = 42 websockets which close from the client side after
+# timeouts up to 8192 seconds.
+# Not included in runtests.jl because this takes two and a half hours to run.
+# Checking against erros equires inspecting REPL.
+
+using Test
+using WebSockets
+import Dates.now
+include("../../benchmark/functions_open_browsers.jl")
+include("timeout_functions.jl")
+
+const WSIDLIST = Vector{String}()
+const WSLIST = Vector{WebSocket}()
+const CLIENTTASKS = Vector{Task}()
+const CLOSINGMESSAGES = Vector{String}()
+
+const T0 = now()
+# At Http 0.7 / WebSockets 1.3, there is no obviously nice interface to limiting
+# the maximum simulconnection pool. We settle for a naughty as well as ugly way, and state our
+# intention to fix this up (sometime). It should not concern timeouts, just
+# our ability to open many sockets at a time.
+@eval WebSockets.HTTP.ConnectionPool default_connection_limit = 32
+# The default ratelimit is below the number of websockets we're intending to open.
+const SERVER = WebSockets.ServerWS(handle, gatekeeper, ratelimit = 0//1)
+const OLDLOGGER = WebSockets.global_logger()
+
+WebSockets.global_logger(WebSocketLogger())
+# Uncomment to include logging messages from HTTP
+#WebSockets.global_logger(WebSocketLogger(shouldlog= (_, _, _, _, _) -> true))
+
+const SERTASK = @async WebSockets.serve(SERVER, 8000)
+open_a_browser()
+# We'll also open a second type of browser. If all are available, the default sequence is
+# ["chrome", "firefox", "iexplore", "safari", "phantomjs"]
+open_a_browser()
+
+# The browsers are working on opening client side websockets. Meanwhile,
+# Julia will open some, too:
+for i = 0:13
+    sec = 2^i
+    wsh = clientwsh(sec)
+    push!(CLIENTTASKS, @async WebSockets.open(wsh, "ws://127.0.0.1:8000"))
+    # We want to yield for asyncronous functions started by incoming
+    # requests from browsers. Otherwise, the browsers could perhaps become bored.
+    yield()
+end
+
+function checktasks()
+    count = 0
+    for clita in CLIENTTASKS
+        count +=1
+        if clita.state == :failed
+            @error "Client websocket task ", count, " failed"
+        end
+    end
+    count
+end
+
+# The time to open a websocket may depend on things like the browser updating,
+# or, for Julia, if compilation is necessary.
+sleep(24)
+if checktasks() == 14
+    @wslog "All client tasks are running without error"
+end
+@test length(WSLIST) == 42
+# Wait for all timeouts (the longest is 8192s)
+sleep(8250)
+put!(SERVER.in("Job well done!"))
+for (ws, wsid) in zip(WSLIST, WSIDLIST)
+    @wslog ws, " ", wsid
+    @test !WebSockets.isopen(ws)
+end
+
+# Check that all the sockets were closed for the right reason
+function checkreasons()
+    for clmsg in CLOSINGMESSAGES
+        @test occursin("seconds are up", clmsg)
+    end
+end
+checkreasons()
+WebSockets.global_logger(OLDLOGGER)
+nothing

--- a/test/timeout/timeout_functions.jl
+++ b/test/timeout/timeout_functions.jl
@@ -1,0 +1,49 @@
+using Test
+using WebSockets
+import Dates.now
+
+"Time since start"
+tss() = " $(Int(round((now() - T0).value / 1000))) s "
+"Server side 'websocket handler'"
+function coroutine(ws)
+    push!(WSLIST, ws)
+    data, success = readguarded(ws)
+    s = ""
+    if success
+        s = String(data)
+        @wslog "This websocket is called ", s, " at ", tss()
+        push!(WSIDLIST, s)
+    else
+        @wslog "Received a closing message instead of a first message", tss()
+        return
+    end
+    try
+        data = read(ws)
+    catch err
+        @wslog s, " was closed at ", tss(), " with message \n\t", err
+        push!(CLOSINGMESSAGES, string(err))
+        return
+    end
+    @wslog "Unexpectedly received a second message from websocket ", s, ". Now closing."
+end
+
+function gatekeeper(req, ws)
+    #@info "\nOrigin: $(WebSockets.origin(req))  subprotocol: $(subprotocol(req))"
+    coroutine(ws)
+end
+
+handle(req) = read("limited life websockets.html") |> WebSockets.Response
+
+"Returns a function intended for taking a client side websocket,
+a 'websocket handler'"
+function clientwsh(timeout::Int)
+    function wsclienthandler(ws)
+        s = "$(timeout)s_timeout_Julia"
+        if !writeguarded(ws, s)
+            @wslog "Could not write from ", ws, " called ", s, " at",  tss()
+            return
+        end
+        sleep(timeout)
+        WebSockets.close(ws, statusnumber = 1000, freereason = "$timeout seconds are up!")
+    end
+end


### PR DESCRIPTION
Added prior to upgrading to HTTP 0.8, for comparison.
modified:   benchmark/functions_open_browsers.jl  # Use WebSocketLogger
new file:   test/timeout/limited life websockets.html # Timeout client side
new file:   test/timeout/timeout.jl        # Browser client, Julia client tests
new file:   test/timeout/timeout_functions.jl # Browser client, Julia client functions