### PR TITLE
allow IPAddr in serve

### DIFF
--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -322,6 +322,9 @@ function ServerWS(h::Function, w::Function; kwargs...)
     ServerWS(RequestHandlerFunction(h), WSHandlerFunction(w); kwargs...)
 end
 
+to_IPAddr(ip::IPAddr) = ip
+to_IPAddr(s::AbstractString) = parse(IpAddr, s)
+
 """
     WebSockets.serve(server::ServerWS, port)
     WebSockets.serve(server::ServerWS, host, port)
@@ -347,7 +350,7 @@ After a suspected connection task failure:
 """
 function serve(serverws::ServerWS, host, port, verbose)
     # An internal reference used for closing.
-    tcpserver = Ref{Union{IOServer, Nothing}}(Sockets.listen(InetAddr(parse(IPAddr, host), port)))
+    tcpserver = Ref{Union{IOServer, Nothing}}(Sockets.listen(InetAddr(to_IPAddr(host), port)))
     # Start a couroutine that sleeps until something is put on the .in channel.
     @async begin
          # Next line will hold until something is put on the channel

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -323,7 +323,7 @@ function ServerWS(h::Function, w::Function; kwargs...)
 end
 
 to_IPAddr(ip::IPAddr) = ip
-to_IPAddr(s::AbstractString) = parse(IpAddr, s)
+to_IPAddr(s::AbstractString) = parse(IPAddr, s)
 
 """
     WebSockets.serve(server::ServerWS, port)

--- a/src/HTTP.jl
+++ b/src/HTTP.jl
@@ -322,8 +322,8 @@ function ServerWS(h::Function, w::Function; kwargs...)
     ServerWS(RequestHandlerFunction(h), WSHandlerFunction(w); kwargs...)
 end
 
-to_IPAddr(ip::IPAddr) = ip
-to_IPAddr(s::AbstractString) = parse(IPAddr, s)
+to_ipaddr(ip::IPAddr) = ip
+to_ipaddr(s::AbstractString) = parse(IPAddr, s)
 
 """
     WebSockets.serve(server::ServerWS, port)
@@ -350,7 +350,7 @@ After a suspected connection task failure:
 """
 function serve(serverws::ServerWS, host, port, verbose)
     # An internal reference used for closing.
-    tcpserver = Ref{Union{IOServer, Nothing}}(Sockets.listen(InetAddr(to_IPAddr(host), port)))
+    tcpserver = Ref{Union{IOServer, Nothing}}(Sockets.listen(InetAddr(to_ipaddr(host), port)))
     # Start a couroutine that sleeps until something is put on the .in channel.
     @async begin
          # Next line will hold until something is put on the channel

--- a/test/client_serverWS_test.jl
+++ b/test/client_serverWS_test.jl
@@ -28,10 +28,17 @@ end
 @info "External server http request"
 @test 200 == WebSockets.HTTP.request("GET", EXTERNALHTTP).status
 
+@info "String to IPAddr conversion"
+let
+    ip = parse(IPAddr, SURL)
+    @test WebSockets.to_ipaddr(SURL) == WebSockets.to_ipaddr(ip) == ip
+end
+
 @info "ServerWS: Open, http response, close. Repeat three times. Takes a while."
 for i = 1:3
     let
-        server = startserver()
+        ip = parse(IPAddr, SURL)
+        server = startserver(url=ip)
         @test 200 == WebSockets.HTTP.request("GET", "http://$SURL:$PORT").status
         close(server)
     end


### PR DESCRIPTION
Mux uses this code and passes the IP address directly (say `localhost = ip"0.0.0.0"::IPAddr`). In this way `serve` supports both passing the string and passing the `IPAddr` object.