### PR TITLE
Fix "MbedTLS.SSLContext does not support byte I/O"

### DIFF
--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -388,7 +388,11 @@ end
 """ Read a frame: turn bytes from the websocket into a WebSocketFragment."""
 function read_frame(ws::WebSocket)
     # Try to read two bytes. There is no guarantee that two bytes are actually allocated.
-    ab = read(ws.socket, 2)
+    ab = Array{UInt8}(undef, 2)
+    if readbytes!(ws.socket, ab) != 2
+      throw(WebSocketError(1006, "Client side closed socket connection"))
+    end
+
     #=
     Browsers will seldom close in the middle of writing to a socket,
     but other clients often do, and the stacktraces can be very long.

--- a/src/WebSockets.jl
+++ b/src/WebSockets.jl
@@ -387,18 +387,21 @@ end
 
 """ Read a frame: turn bytes from the websocket into a WebSocketFragment."""
 function read_frame(ws::WebSocket)
-    if eof(ws.socket)
-        throw(WebSocketError(1006, "Client side closed socket connection"))
-    end
-    # Read first byte
-    a = read(ws.socket, UInt8)
+    # Try to read two bytes. There is no guarantee that two bytes are actually allocated.
+    ab = read(ws.socket, 2)
+    #=
+    Browsers will seldom close in the middle of writing to a socket,
+    but other clients often do, and the stacktraces can be very long.
+    ab can be assigned, but of length 1. Use an enclosing try..catch in the calling function
+    =#
+    a = ab[1]
     fin    = (a & 0b1000_0000) >>> 7  # If fin, then is final fragment
     rsv1   = a & 0b0100_0000  # If not 0, fail.
     rsv2   = a & 0b0010_0000  # If not 0, fail.
     rsv3   = a & 0b0001_0000  # If not 0, fail.
     opcode = a & 0b0000_1111  # If not known code, fail.
 
-    b = read(ws.socket, UInt8)
+    b = ab[2]
     mask = (b & 0b1000_0000) >>> 7
     hasmask = mask != 0
 

--- a/test/client_listen_test.jl
+++ b/test/client_listen_test.jl
@@ -21,21 +21,21 @@ for i = 1:3
     end
 end
 
-@info "Listen: Client side initates message exchange."
+@info "Listen: Client side initiates message exchange."
 let
     server = startserver(url=SURL,port=PORT)
     WebSockets.open(initiatingws, "ws://$SURL:$PORT")
     close(server)
 end
 
-@info "Listen: Server side initates message exchange."
+@info "Listen: Server side initiates message exchange."
 let
     server = startserver(url=SURL,port=PORT)
     WebSockets.open(echows, "ws://$SURL:$PORT", subprotocol = SUBPROTOCOL)
     close(server)
 end
 
-@info "Listen: Server side initates message exchange. Close from within server side handler."
+@info "Listen: Server side initiates message exchange. Close from within server side handler."
 let
     server = startserver(url=SURL,port=PORT)
     WebSockets.open(echows, "ws://$SURL:$PORT", subprotocol = SUBPROTOCOL_CLOSE)

--- a/test/client_serverWS_test.jl
+++ b/test/client_serverWS_test.jl
@@ -44,21 +44,21 @@ for i = 1:3
     end
 end
 
-@info "ServerWS: Client side initates message exchange."
+@info "ServerWS: Client side initiates message exchange."
 let
     server = startserver()
     WebSockets.open(initiatingws, "ws://$SURL:$PORT")
     close(server)
 end
 
-@info "ServerWS: Server side initates message exchange."
+@info "ServerWS: Server side initiates message exchange."
 let
     server = startserver()
     WebSockets.open(echows, "ws://$SURL:$PORT", subprotocol = SUBPROTOCOL)
     close(server)
 end
 
-@info "ServerWS: Server side initates message exchange. Close from within server side handler."
+@info "ServerWS: Server side initiates message exchange. Close from within server side handler."
 let
     server = startserver()
     WebSockets.open(echows, "ws://$SURL:$PORT", subprotocol = SUBPROTOCOL_CLOSE)

--- a/test/client_test.jl
+++ b/test/client_test.jl
@@ -34,7 +34,7 @@ sleep(1)
 res = WebSockets.open((_) -> nothing, URL, subprotocol = "unapproved");
 @test res.status == 400
 
-@info "Try to open a websocket with uknown port. Takes a few seconds."
+@info "Try to open a websocket with unknown port. Takes a few seconds."
 sleep(1)
 global caughterr = WebSockets.WebSocketClosedError("")
 try
@@ -45,7 +45,7 @@ end
 @test typeof(caughterr) <: WebSocketClosedError
 @test caughterr.message == " while open ws|client: connect: connection refused (ECONNREFUSED)"
 
-@info "Try open with uknown scheme."
+@info "Try open with unknown scheme."
 sleep(1)
 global caughterr = ArgumentError("")
 try


### PR DESCRIPTION
Close #169

In particular see In https://github.com/JuliaWeb/WebSockets.jl/issues/169#issuecomment-758198121 for additional details

This PR started by reverting to the "old" working code, but it may evolve differently if there is any potentially better solution. Moreover, it would be valuable to find a way for testing this case.